### PR TITLE
Fix for removal of cms_section reposition endpoint from Platform API.

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/cms/page.es6
+++ b/backend/app/assets/javascripts/spree/backend/cms/page.es6
@@ -83,12 +83,14 @@ function reloadPreview() {
 }
 
 function handleSectionReposition(evt) {
+  const sectionId = parseInt(evt.item.dataset.sectionId, 10)
   const data = {
-    section_id: parseInt(evt.item.dataset.sectionId, 10),
-    new_position_idx: parseInt(evt.newIndex, 10)
+    cms_section: {
+      position: parseInt(evt.newIndex, 10) + 1
+    }
   }
 
-  fetch(Spree.routes.sections_api_v2 + '/reposition', {
+  fetch(`${Spree.routes.sections_api_v2}/${sectionId}`, {
     method: 'PATCH',
     headers: {
       Authorization: 'Bearer ' + OAUTH_TOKEN,


### PR DESCRIPTION
As the platform API evolved the `cms_section` reposition action was removed, this PR updates the javascript to call update on the position.