### PR TITLE
Fix switching promotions, preferred_currency select issue.

### DIFF
--- a/app/assets/javascripts/spree/backend/promotions.js
+++ b/app/assets/javascripts/spree/backend/promotions.js
@@ -16,10 +16,12 @@ function initProductActions () {
         $warning.hide()
         $settings.show()
         $settings.find('input').removeProp('disabled')
+        $settings.find('select').removeProp('disabled')
       } else {
         $warning.show()
         $settings.hide()
         $settings.find('input').prop('disabled', 'disabled')
+        $settings.find('select').prop('disabled', 'disabled')
       }
     })
   })


### PR DESCRIPTION
Need to disable select if a promotion action calculator is changed, else the params get dragged through.