### PR TITLE
feat: allow disabling cms_page wysiwyg editor

### DIFF
--- a/app/helpers/spree/admin/base_helper.rb
+++ b/app/helpers/spree/admin/base_helper.rb
@@ -286,6 +286,10 @@ module Spree
         end
       end
 
+      def cms_page_wysiwyg_editor_enabled?
+        Spree::Backend::Config[:cms_page_wysiwyg_editor_enabled]
+      end
+
       def product_wysiwyg_editor_enabled?
         Spree::Backend::Config[:product_wysiwyg_editor_enabled]
       end

--- a/app/models/spree/backend_configuration.rb
+++ b/app/models/spree/backend_configuration.rb
@@ -11,6 +11,7 @@ module Spree
     preference :locale, :string, default: Rails.application.config.i18n.default_locale
     preference :variants_per_page, :integer, default: Kaminari.config.default_per_page
     preference :menus_per_page, :integer, default: Kaminari.config.default_per_page
+    preference :cms_page_wysiwyg_editor_enabled, :boolean, default: true
     preference :product_wysiwyg_editor_enabled, :boolean, default: true
     preference :taxon_wysiwyg_editor_enabled, :boolean, default: true
     preference :show_only_complete_orders_by_default, :boolean, default: true

--- a/app/views/spree/admin/cms_pages/_form.html.erb
+++ b/app/views/spree/admin/cms_pages/_form.html.erb
@@ -124,7 +124,7 @@
   <div class="row">
     <div class="col-12">
       <%= f.field_container :content, class: ['form-group']  do %>
-        <%= f.text_area :content, { rows: 22, class: 'spree-rte'} %>
+        <%= f.text_area :content, { rows: 22, class: "form-control #{"spree-rte" if cms_page_wysiwyg_editor_enabled? }" } %>
         <%= f.error_message_on :content %>
       <% end %>
     </div>


### PR DESCRIPTION
We want to disable this in an easy way and use markdown instead.