### PR TITLE
Move 'form-group' up to the field_container method.

### DIFF
--- a/app/helpers/spree/admin/base_helper.rb
+++ b/app/helpers/spree/admin/base_helper.rb
@@ -23,7 +23,7 @@ module Spree
 
       def field_container(model, method, options = {}, &block)
         css_classes = options[:class].to_a
-        css_classes << 'field'
+        css_classes << 'form-group'
         css_classes << 'withError' if error_message_on(model, method).present?
         content_tag(
           :div, capture(&block),

--- a/app/views/spree/admin/adjustments/_form.html.erb
+++ b/app/views/spree/admin/adjustments/_form.html.erb
@@ -1,10 +1,10 @@
 <div data-hook="admin_adjustment_form_fields">
-  <%= f.field_container :amount, class: ['form-group'] do %>
+  <%= f.field_container :amount do %>
     <%= f.label :amount, raw(Spree.t(:amount) + required_span_tag) %>
     <%= text_field :adjustment, :amount, class: 'form-control' %>
     <%= f.error_message_on :amount %>
   <% end %>
-  <%= f.field_container :label, class: ['form-group'] do %>
+  <%= f.field_container :label do %>
     <%= f.label :label, raw(Spree.t(:description) + required_span_tag) %>
     <%= text_field :adjustment, :label, class: 'form-control' %>
     <%= f.error_message_on :label %>

--- a/app/views/spree/admin/cms_pages/_form.html.erb
+++ b/app/views/spree/admin/cms_pages/_form.html.erb
@@ -6,7 +6,7 @@
         <div class="card-header col-12">
           <div class="row no-gutters pb-0">
             <div class="col d-flex justify-content-start align-items-center">
-              <%= f.field_container :visible, class: ['form-group pb-0 mb-0'] do %>
+              <%= f.field_container :visible, class: ['pb-0 mb-0'] do %>
                 <div class="custom-control custom-switch custom-switch-md">
                   <%= f.check_box :visible, class: 'custom-control-input', data: {cms_page_id: @cms_page.id} %>
                   <label class="custom-control-label" for="cms_page_visible"></label>
@@ -36,13 +36,13 @@
         <div class="card-body pb-2">
           <div class="row pb-0">
 
-            <%= f.field_container :title, class: ['form-group col-12 col-md-6'] do %>
+            <%= f.field_container :title, class: ['col-12 col-md-6'] do %>
               <%= f.label :title, raw(Spree.t('admin.cms.title') + required_span_tag) %>
               <%= f.text_field :title, class: 'form-control', required: true %>
               <%= f.error_message_on :title %>
             <% end %>
 
-            <%= f.field_container :type, class: ['form-group col-12 col-md-6'] do %>
+            <%= f.field_container :type, class: ['col-12 col-md-6'] do %>
               <%= f.label :type, Spree.t('admin.cms.page_type') %>
               <%= f.select(:type, spree_humanize_dropdown_values('Spree::CmsPage', {const: 'TYPES'}), {include_blank: false}, class: 'select2') %>
               <%= f.error_message_on :type %>
@@ -61,19 +61,19 @@
           <div class="<% unless %w[new create].include? controller.action_name %>collapse<% end %>" id="cmsPageSettings">
             <div class="row pb-0">
               <div class="col-12"><hr></div>
-              <%= f.field_container :locale, class: ['form-group col-12 col-md-4'] do %>
+              <%= f.field_container :locale, class: ['col-12 col-md-4'] do %>
                 <%= f.label :language %>
                 <%= f.select :locale, options_from_collection_for_select(supported_locales_options, :last, :first, @cms_page.locale || I18n.locale), {}, { class: 'select2' } %>
                 <%= f.error_message_on :default_locale %>
               <% end %>
 
-              <%= f.field_container :meta_title, class: ['form-group col-12 col-md-4'] do %>
+              <%= f.field_container :meta_title, class: ['col-12 col-md-4'] do %>
                 <%= f.label :meta_title, Spree.t('admin.cms.meta_title') %>
                 <%= f.text_field :meta_title, class: 'form-control' %>
                 <%= f.error_message_on :meta_title %>
               <% end %>
 
-              <%= f.field_container :slug, class: ['form-group col-12 col-md-4'] do %>
+              <%= f.field_container :slug, class: ['col-12 col-md-4'] do %>
                 <div id="noHomePage">
                   <%= f.label :slug, Spree.t('slug') %>
                   <%= f.text_field :slug, class: 'form-control', disabled: @cms_page.homepage? %>
@@ -81,7 +81,7 @@
                 </div>
               <% end %>
 
-              <%= f.field_container :meta_description, class: ['form-group col-12'] do %>
+              <%= f.field_container :meta_description, class: ['col-12'] do %>
                 <%= f.label :meta_description, Spree.t('admin.cms.meta_description') %>
                 <%= f.text_area :meta_description, { rows: 3, class: 'form-control' } %>
                 <%= f.error_message_on :meta_description %>
@@ -123,7 +123,7 @@
 <% if @cms_page.type == 'Spree::Cms::Pages::StandardPage' %>
   <div class="row">
     <div class="col-12">
-      <%= f.field_container :content, class: ['form-group']  do %>
+      <%= f.field_container :content  do %>
         <%= f.text_area :content, { rows: 22, class: 'spree-rte'} %>
         <%= f.error_message_on :content %>
       <% end %>

--- a/app/views/spree/admin/cms_sections/_form.html.erb
+++ b/app/views/spree/admin/cms_sections/_form.html.erb
@@ -1,14 +1,14 @@
 <div data-hook="admin_cms_section_form_fields">
   <div class="row">
     <div class="col-12 col-md-6">
-      <%= f.field_container :name, class: ['form-group'] do %>
+      <%= f.field_container :name do %>
         <%= f.label :name, raw(Spree.t(:name) + required_span_tag) %>
         <%= f.text_field :name, class: 'form-control', required: true, autocomplete: false %>
         <%= f.error_message_on :name %>
       <% end %>
     </div>
     <div class="col-12 col-md-6">
-      <%= f.field_container :type, class: ['form-group'] do %>
+      <%= f.field_container :type do %>
         <%= f.label :type, Spree.t('admin.cms.section_type') %>
         <%= f.select(:type, spree_humanize_dropdown_values('Spree::CmsSection', {const: 'TYPES'}), {include_blank: false}) %>
         <%= f.error_message_on :type %>

--- a/app/views/spree/admin/cms_sections/types/_featured_article.html.erb
+++ b/app/views/spree/admin/cms_sections/types/_featured_article.html.erb
@@ -1,24 +1,24 @@
 <div class="row">
   <div class="col-12 col-md-4">
-    <%= f.field_container :title, class: ['form-group'] do %>
+    <%= f.field_container :title do %>
       <%= f.label :title, Spree.t('admin.cms.title') %>
       <%= f.text_field :title, class: 'form-control' %>
       <%= f.error_message_on :title %>
     <% end %>
 
-    <%= f.field_container :subtitle, class: ['form-group'] do %>
+    <%= f.field_container :subtitle do %>
       <%= f.label :subtitle, Spree.t('admin.cms.subtitle') %>
       <%= f.text_field :subtitle, class: 'form-control' %>
       <%= f.error_message_on :subtitle %>
     <% end %>
 
-    <%= f.field_container :button_text, class: ['form-group'] do %>
+    <%= f.field_container :button_text do %>
       <%= f.label :button_text, Spree.t('admin.cms.button_text') %>
       <%= f.text_field :button_text, class: 'form-control' %>
       <%= f.error_message_on :button_text %>
     <% end %>
 
-    <%= f.field_container :gutters, class: ['form-group'] do %>
+    <%= f.field_container :gutters do %>
       <%= f.label :gutters, Spree.t('admin.cms.gutters') %>
       <%= f.select(:gutters, @cms_section.gutters_sizes, {include_blank: false}, class: 'select2') %>
       <%= f.error_message_on :gutters %>
@@ -26,7 +26,7 @@
 
   </div>
   <div class="col-12 col-md-8">
-    <%= f.field_container :rte_content, class: ['form-group'] do %>
+    <%= f.field_container :rte_content do %>
       <%= f.label :rte_content, Spree.t('admin.cms.content') %>
       <%= f.text_area :rte_content, { rows: "20", class: 'form-control spree-rte' } %>
       <%= f.error_message_on :rte_content %>
@@ -34,7 +34,7 @@
   </div>
   <div class="col-12"><hr></div>
   <div class="col-12 col-md-6">
-    <%= f.field_container :linked_resource_type, class: ['form-group'] do %>
+    <%= f.field_container :linked_resource_type do %>
       <%= f.label :linked_resource_type, Spree.t('admin.navigation.link_to') %>
       <%= f.select(:linked_resource_type,
           spree_humanize_dropdown_values('Spree::Cms::Sections::FeaturedArticle',

--- a/app/views/spree/admin/cms_sections/types/_hero_image.html.erb
+++ b/app/views/spree/admin/cms_sections/types/_hero_image.html.erb
@@ -1,25 +1,25 @@
 <div class="row pb-0">
   <div class="col-12 col-md-6">
-    <%= f.field_container :title, class: ['form-group'] do %>
+    <%= f.field_container :title do %>
       <%= f.label :title, Spree.t('admin.cms.title') %>
       <%= f.text_field :title, class: 'form-control' %>
       <%= f.error_message_on :title %>
     <% end %>
 
-    <%= f.field_container :button_text, class: ['form-group'] do %>
+    <%= f.field_container :button_text do %>
       <%= f.label :button_text, Spree.t('admin.cms.button_text') %>
       <%= f.text_field :button_text, class: 'form-control' %>
       <%= f.error_message_on :button_text %>
     <% end %>
 
     <div class="row">
-      <%= f.field_container :fit, class: ['form-group col-6'] do %>
+      <%= f.field_container :fit, class: ['col-6'] do %>
         <%= f.label :fit, Spree.t('admin.cms.fit') %>
         <%= f.select(:fit, @cms_section.boundaries, {include_blank: false}, class: 'select2') %>
         <%= f.error_message_on :fit %>
       <% end %>
 
-      <%= f.field_container :gutters, class: ['form-group col-6'] do %>
+      <%= f.field_container :gutters, class: ['col-6'] do %>
         <%= f.label :gutters, Spree.t('admin.cms.gutters') %>
         <%= f.select(:gutters, @cms_section.gutters_sizes, {include_blank: false}, class: 'select2') %>
         <%= f.error_message_on :gutters %>
@@ -27,7 +27,7 @@
     </div>
   </div>
   <div class="col-12 col-md-6 pt-4">
-    <%= f.field_container :image_one, class: ['form-group'] do %>
+    <%= f.field_container :image_one do %>
       <% if @cms_section.image_one.attached? && @cms_section.image_one.variable? %>
         <figure class="admin-img-holder">
           <%= image_tag main_app.url_for(@cms_section.image_one.variant(resize: '244x104>')) %>
@@ -45,7 +45,7 @@
   </div>
   <div class="col-12"><hr></div>
   <div class="col-12 col-md-6">
-    <%= f.field_container :linked_resource_type, class: ['form-group'] do %>
+    <%= f.field_container :linked_resource_type do %>
       <%= f.label :linked_resource_type, Spree.t('admin.navigation.link_to') %>
       <%= f.select(:linked_resource_type,
           spree_humanize_dropdown_values('Spree::Cms::Sections::HeroImage',

--- a/app/views/spree/admin/cms_sections/types/_image_gallery.html.erb
+++ b/app/views/spree/admin/cms_sections/types/_image_gallery.html.erb
@@ -9,7 +9,7 @@
       </div>
     </div>
 
-    <%= f.field_container :layout_style, class: ['form-group'] do %>
+    <%= f.field_container :layout_style do %>
       <%= f.label :layout_style, Spree.t('admin.cms.image_gallery.layout_style') %>
       <%= f.select(:layout_style,
           spree_humanize_dropdown_values('Spree::Cms::Sections::ImageGallery',
@@ -25,7 +25,7 @@
     <div id="image_a_details" class="card p-3">
       <div class="text-center">
         <h4 class="pb-2"><%= Spree.t('admin.cms.image_gallery.image_a') %></h4>
-        <%= f.field_container :image_one, class: ['form-group'] do %>
+        <%= f.field_container :image_one do %>
           <% if @cms_section.image_one.attached? && @cms_section.image_one.variable? %>
             <figure class="admin-img-holder">
               <%= image_tag main_app.url_for(@cms_section.image_one.variant(resize: '244x104>')) %>
@@ -42,7 +42,7 @@
       </div>
       <small class="text-muted mb-4"><%= Spree.t('admin.cms.image_gallery.square_image') %></small>
 
-      <%= f.field_container :title_one, class: ['form-group'] do %>
+      <%= f.field_container :title_one do %>
         <%= f.label :title_one, Spree.t('admin.cms.title') %>
         <%= f.text_field :title_one, class: 'form-control' %>
         <%= f.error_message_on :title_one %>
@@ -50,7 +50,7 @@
 
       <div class="col-12"><hr></div>
       <% unless rails_5? %>
-        <%= f.field_container :link_type_one, class: ['form-group'] do %>
+        <%= f.field_container :link_type_one do %>
           <%= f.label :link_type_one, Spree.t('admin.navigation.link_to') %>
           <%= f.select(:link_type_one,
               spree_humanize_dropdown_values('Spree::Cms::Sections::ImageGallery',
@@ -69,7 +69,7 @@
     <div id="image_b_details" class="card p-3">
       <div class="text-center">
         <h4 class="pb-2"><%= Spree.t('admin.cms.image_gallery.image_b') %></h4>
-        <%= f.field_container :image_two, class: ['form-group'] do %>
+        <%= f.field_container :image_two do %>
           <% if @cms_section.image_two.attached? && @cms_section.image_two.variable? %>
             <figure class="admin-img-holder">
               <%= image_tag main_app.url_for(@cms_section.image_two.variant(resize: '244x104>')) %>
@@ -86,7 +86,7 @@
       </div>
       <small class="text-muted mb-4"><%= Spree.t('admin.cms.image_gallery.tall_image') %></small>
 
-      <%= f.field_container :title_two, class: ['form-group'] do %>
+      <%= f.field_container :title_two do %>
         <%= f.label :title_two, Spree.t('admin.cms.title') %>
         <%= f.text_field :title_two, class: 'form-control' %>
         <%= f.error_message_on :title_two %>
@@ -94,7 +94,7 @@
 
       <div class="col-12"><hr></div>
       <% unless rails_5? %>
-        <%= f.field_container :link_type_two, class: ['form-group'] do %>
+        <%= f.field_container :link_type_two do %>
           <%= f.label :link_type_two, Spree.t('admin.navigation.link_to') %>
           <%= f.select(:link_type_two,
               spree_humanize_dropdown_values('Spree::Cms::Sections::ImageGallery',
@@ -113,7 +113,7 @@
     <div id="image_c_details" class="card p-3">
       <div class="text-center">
         <h4 class="pb-2"><%= Spree.t('admin.cms.image_gallery.image_c') %></h4>
-        <%= f.field_container :image_three, class: ['form-group'] do %>
+        <%= f.field_container :image_three do %>
           <% if @cms_section.image_three.attached? && @cms_section.image_three.variable? %>
             <figure class="admin-img-holder">
               <%= image_tag main_app.url_for(@cms_section.image_three.variant(resize: '244x104>')) %>
@@ -130,7 +130,7 @@
       </div>
       <small class="text-muted mb-4"><%= Spree.t('admin.cms.image_gallery.square_image') %></small>
 
-      <%= f.field_container :title_three, class: ['form-group'] do %>
+      <%= f.field_container :title_three do %>
         <%= f.label :title_three, Spree.t('admin.cms.title') %>
         <%= f.text_field :title_three, class: 'form-control' %>
         <%= f.error_message_on :title_three %>
@@ -138,7 +138,7 @@
 
       <div class="col-12"><hr></div>
       <% unless rails_5? %>
-        <%= f.field_container :link_type_three, class: ['form-group'] do %>
+        <%= f.field_container :link_type_three do %>
           <%= f.label :link_type_three, Spree.t('admin.navigation.link_to') %>
           <%= f.select(:link_type_three,
               spree_humanize_dropdown_values('Spree::Cms::Sections::ImageGallery',
@@ -156,13 +156,13 @@
 
 <div class="row pb-0">
   <div class="col-12"> <hr></div>
-  <%= f.field_container :fit, class: ['form-group col-6'] do %>
+  <%= f.field_container :fit, class: ['col-6'] do %>
     <%= f.label :fit, Spree.t('admin.cms.fit') %>
     <%= f.select(:fit, @cms_section.boundaries, {include_blank: false}, class: 'select2') %>
     <%= f.error_message_on :fit %>
   <% end %>
 
-  <%= f.field_container :display_labels, class: ['form-group col-6'] do %>
+  <%= f.field_container :display_labels, class: ['col-6'] do %>
     <%= f.label :display_labels, Spree.t('admin.cms.image_gallery.display_labels') %>
     <%= f.select(:display_labels,
         spree_humanize_dropdown_values('Spree::Cms::Sections::ImageGallery',

--- a/app/views/spree/admin/cms_sections/types/_rich_text_content.html.erb
+++ b/app/views/spree/admin/cms_sections/types/_rich_text_content.html.erb
@@ -1,4 +1,4 @@
-<%= f.field_container :rte_content, class: ['form-group mb-0'] do %>
+<%= f.field_container :rte_content, class: ['mb-0'] do %>
   <%= f.text_area :rte_content, { rows: "20", class: 'form-control spree-rte' } %>
   <%= f.error_message_on :rte_content %>
 <% end %>

--- a/app/views/spree/admin/cms_sections/types/_side_by_side_images.html.erb
+++ b/app/views/spree/admin/cms_sections/types/_side_by_side_images.html.erb
@@ -3,7 +3,7 @@
     <div id="left_image_details" class="card p-3">
       <div class="text-center">
         <h4 class="pb-2"><%= Spree.t('admin.cms.side_by_side.left_image') %></h4>
-        <%= f.field_container :image_one, class: ['form-group'] do %>
+        <%= f.field_container :image_one do %>
           <% if @cms_section.image_one.attached? && @cms_section.image_one.variable? %>
             <figure class="admin-img-holder">
               <%= image_tag main_app.url_for(@cms_section.image_one.variant(resize: '244x104>')) %>
@@ -13,7 +13,7 @@
               <%= image_tag main_app.url_for(@cms_section.image_one) %>
             </figure>
           <% end %>
-          <%= f.field_container :image_one, class: ['form-group mb-0'] do %>
+          <%= f.field_container :image_one, class: ['mb-0'] do %>
             <%= f.file_field :image_one %>
             <%= f.error_message_on :image_one %>
           <% end %>
@@ -21,13 +21,13 @@
         <% end %>
       </div>
 
-      <%= f.field_container :title_one, class: ['form-group'] do %>
+      <%= f.field_container :title_one do %>
         <%= f.label :title_one, Spree.t('admin.cms.title') %>
         <%= f.text_field :title_one, class: 'form-control' %>
         <%= f.error_message_on :title_one %>
       <% end %>
 
-      <%= f.field_container :subtitle_one, class: ['form-group'] do %>
+      <%= f.field_container :subtitle_one do %>
         <%= f.label :subtitle_one, Spree.t('admin.cms.subtitle') %>
         <%= f.text_field :subtitle_one, class: 'form-control' %>
         <%= f.error_message_on :subtitle_one %>
@@ -35,7 +35,7 @@
 
       <div class="col-12"><hr></div>
       <% unless rails_5? %>
-        <%= f.field_container :link_type_one, class: ['form-group'] do %>
+        <%= f.field_container :link_type_one do %>
           <%= f.label :link_type_one, Spree.t('admin.navigation.link_to') %>
           <%= f.select(:link_type_one,
               spree_humanize_dropdown_values('Spree::Cms::Sections::SideBySideImages',
@@ -54,7 +54,7 @@
     <div id="right_image_details" class="card p-3">
       <div class="text-center">
         <h4 class="pb-2"><%= Spree.t('admin.cms.side_by_side.right_image') %></h4>
-        <%= f.field_container :image_two, class: ['form-group'] do %>
+        <%= f.field_container :image_two do %>
           <% if @cms_section.image_two.attached? && @cms_section.image_two.variable? %>
             <figure class="admin-img-holder">
               <%= image_tag main_app.url_for(@cms_section.image_two.variant(resize: '244x104>')) %>
@@ -64,7 +64,7 @@
               <%= image_tag main_app.url_for(@cms_section.image_two) %>
             </figure>
           <% end %>
-          <%= f.field_container :image_two, class: ['form-group mb-0'] do %>
+          <%= f.field_container :image_two, class: ['mb-0'] do %>
             <%= f.file_field :image_two %>
             <%= f.error_message_on :image_two %>
           <% end %>
@@ -72,13 +72,13 @@
         <% end %>
       </div>
 
-      <%= f.field_container :title_two, class: ['form-group'] do %>
+      <%= f.field_container :title_two do %>
         <%= f.label :title_two, Spree.t('admin.cms.title') %>
         <%= f.text_field :title_two, class: 'form-control' %>
         <%= f.error_message_on :title_two %>
       <% end %>
 
-      <%= f.field_container :subtitle_two, class: ['form-group'] do %>
+      <%= f.field_container :subtitle_two do %>
         <%= f.label :subtitle_two, Spree.t('admin.cms.subtitle') %>
         <%= f.text_field :subtitle_two, class: 'form-control' %>
         <%= f.error_message_on :subtitle_two %>
@@ -87,7 +87,7 @@
       <div class="col-12"><hr></div>
 
       <% unless rails_5? %>
-        <%= f.field_container :link_type_two, class: ['form-group'] do %>
+        <%= f.field_container :link_type_two do %>
           <%= f.label :link_type_two, Spree.t('admin.navigation.link_to') %>
           <%= f.select(:link_type_two,
               spree_humanize_dropdown_values('Spree::Cms::Sections::SideBySideImages',
@@ -104,7 +104,7 @@
 
 <div class="col-12"><hr></div>
   <div class="col-6">
-    <%= f.field_container :fit, class: ['form-group'] do %>
+    <%= f.field_container :fit do %>
       <%= f.label :fit, Spree.t('admin.cms.fit') %>
       <%= f.select(:fit, @cms_section.boundaries, {include_blank: false}, class: 'select2') %>
       <%= f.error_message_on :fit %>
@@ -112,7 +112,7 @@
   </div>
 
   <div class="col-6">
-    <%= f.field_container :gutters, class: ['form-group'] do %>
+    <%= f.field_container :gutters do %>
       <%= f.label :gutters, Spree.t('admin.cms.set_gutters') %>
       <%= f.select(:gutters, @cms_section.gutters_sizes, {include_blank: false}, class: 'select2') %>
       <%= f.error_message_on :gutters %>

--- a/app/views/spree/admin/countries/_form.html.erb
+++ b/app/views/spree/admin/countries/_form.html.erb
@@ -1,23 +1,23 @@
 <div data-hook="admin_country_form_fields">
-  <%= f.field_container :name, class: ['form-group'], 'data-hook' => 'name' do %>
+  <%= f.field_container :name, 'data-hook' => 'name' do %>
     <%= f.label :name, Spree.t(:name) %>
     <%= f.text_field :name, class: 'form-control' %>
     <%= f.error_message_on :name %>
   <% end %>
 
-  <%= f.field_container :iso_name, class: ['form-group'], 'data-hook' => 'iso_name' do %>
+  <%= f.field_container :iso_name, 'data-hook' => 'iso_name' do %>
     <%= f.label :iso_name, Spree.t(:iso_name) %>
     <%= f.text_field :iso_name, class: 'form-control' %>
     <%= f.error_message_on :iso_name %>
   <% end %>
 
-  <%= f.field_container :iso, class: ['form-group'], 'data-hook' => 'iso' do %>
+  <%= f.field_container :iso, 'data-hook' => 'iso' do %>
     <%= f.label :iso, Spree.t(:iso) %>
     <%= f.text_field :iso, class: 'form-control' %>
     <%= f.error_message_on :iso %>
   <% end %>
 
-  <%= f.field_container :iso3, class: ['form-group'], 'data-hook' => 'iso3' do %>
+  <%= f.field_container :iso3, 'data-hook' => 'iso3' do %>
     <%= f.label :iso3, Spree.t(:iso3) %>
     <%= f.text_field :iso3, class: 'form-control' %>
     <%= f.error_message_on :iso3 %>

--- a/app/views/spree/admin/customer_returns/new.html.erb
+++ b/app/views/spree/admin/customer_returns/new.html.erb
@@ -22,7 +22,7 @@
           <% end %>
         </fieldset>
 
-        <%= f.field_container :stock_location, class: ['form-group'] do %>
+        <%= f.field_container :stock_location do %>
           <%= f.label :stock_location, Spree.t(:stock_location) %> <span class="required">*</span>
           <%= f.select :stock_location_id, Spree::StockLocation.order_default.active.to_a.collect{|l|[l.name.humanize, l.id]}, {include_blank: true}, {class: 'select2-clear', "data-placeholder" => Spree.t(:select_a_stock_location)} %>
           <%= f.error_message_on :stock_location %>

--- a/app/views/spree/admin/menu_items/_form.html.erb
+++ b/app/views/spree/admin/menu_items/_form.html.erb
@@ -6,13 +6,13 @@
           <h5 class="mb-0"><%= Spree.t('admin.navigation.settings') %></h5>
         </div>
         <div class="card-body">
-          <%= f.field_container :item_type, class: ['form-group'] do %>
+          <%= f.field_container :item_type do %>
             <%= f.label :item_type, Spree.t('admin.navigation.item_type') %>
             <%= f.select(:item_type, @menu_item_types, {include_blank: false}) %>
             <%= f.error_message_on :item_type %>
           <% end %>
 
-          <%= f.field_container :code, class: ['form-group'] do %>
+          <%= f.field_container :code do %>
             <%= f.label :code, Spree.t('admin.navigation.code') %>
             <%= f.text_field :code, class: 'form-control' %>
             <%= f.error_message_on :code %>
@@ -21,7 +21,7 @@
             </small>
           <% end %>
 
-          <%= f.field_container :parent_id, class: ['form-group'] do %>
+          <%= f.field_container :parent_id do %>
             <%= f.label :parent_id, Spree.t('admin.navigation.nested_under') %>
             <%= f.select :parent_id, nested_set_options(@menu.menu_items, @menu_item) {|i| "#{'-' * i.level} #{i.name}" }, {include_blank: false}, {class: 'select2'} %>
             <%= f.error_message_on :parent_id %>
@@ -39,13 +39,13 @@
           <h5 class="mb-0"><%= Spree.t('admin.navigation.public_details') %></h5>
         </div>
         <div class="card-body">
-          <%= f.field_container :name, class: ['form-group'] do %>
+          <%= f.field_container :name do %>
             <%= f.label :name, raw(Spree.t(:name) + required_span_tag) %>
             <%= f.text_field :name, class: 'form-control', required: true %>
             <%= f.error_message_on :name %>
           <% end %>
 
-          <%= f.field_container :subtitle, class: ['form-group'] do %>
+          <%= f.field_container :subtitle do %>
             <%= f.label :subtitle, Spree.t('admin.navigation.subtitle') %>
             <%= f.text_field :subtitle, class: 'form-control' %>
             <%= f.error_message_on :subtitle %>
@@ -93,7 +93,7 @@
           <div class="card-body">
             <div class="row">
               <div class="col-12 col-md-6">
-                <%= f.field_container :linked_resource_type, class: ['form-group'] do %>
+                <%= f.field_container :linked_resource_type do %>
                   <%= f.label :linked_resource_type, Spree.t('admin.navigation.link_to') %>
                   <%= f.select(:linked_resource_type, spree_humanize_dropdown_values('Spree::MenuItem', {const: 'LINKED_RESOURCE_TYPE'}), {include_blank: false}, class: 'link_switcher') %>
                   <%= f.error_message_on :linked_resource_type %>

--- a/app/views/spree/admin/menus/_form.html.erb
+++ b/app/views/spree/admin/menus/_form.html.erb
@@ -1,17 +1,17 @@
 <div data-hook="admin_menu_form_fields" class="row">
-  <%= f.field_container :name, class: ['form-group col-12 col-md-4'] do %>
+  <%= f.field_container :name, class: ['col-12 col-md-4'] do %>
     <%= f.label :name, raw(Spree.t(:name) + required_span_tag) %>
     <%= f.text_field :name, class: 'form-control', required: true %>
     <%= f.error_message_on :name %>
   <% end %>
 
-  <%= f.field_container :location, class: ['form-group col-12 col-md-4'] do %>
+  <%= f.field_container :location, class: ['col-12 col-md-4'] do %>
     <%= f.label :location, Spree.t('location') %>
     <%= f.select(:location, spree_humanize_dropdown_values('Spree::Menu', { const: 'MENU_LOCATIONS', paramterize_values: true }), {include_blank: false}, class: 'select2') %>
     <%= f.error_message_on :location %>
   <% end %>
 
-  <%= f.field_container :locale, class: ['form-group col-12 col-md-4'] do %>
+  <%= f.field_container :locale, class: ['col-12 col-md-4'] do %>
     <%= f.label :language %>
     <%= f.select :locale, options_from_collection_for_select(all_locales_options, :last, :first, @menu.locale || I18n.locale), {}, { class: 'select2' } %>
     <%= f.error_message_on :default_locale %>

--- a/app/views/spree/admin/option_types/_form.html.erb
+++ b/app/views/spree/admin/option_types/_form.html.erb
@@ -1,6 +1,6 @@
 <div data-hook="admin_option_type_form_fields" class="row">
   <div class="col-12 col-md-6">
-    <%= f.field_container :name, class: ['form-group'] do %>
+    <%= f.field_container :name do %>
       <%= f.label :name, Spree.t(:name) %> <span class="required">*</span>
       <%= f.text_field :name, class: "form-control" %>
       <%= f.error_message_on :name %>
@@ -8,7 +8,7 @@
   </div>
 
   <div class="col-12 col-md-6">
-    <%= f.field_container :presentation, class: ['form-group'] do %>
+    <%= f.field_container :presentation do %>
       <%= f.label :presentation, Spree.t(:presentation) %> <span class="required">*</span>
       <%= f.text_field :presentation, class: "form-control" %>
       <%= f.error_message_on :presentation %>
@@ -16,7 +16,7 @@
   </div>
 
   <div class="col-12 col-md-6">
-    <%= f.field_container :filterable, class: ['form-group'] do %>
+    <%= f.field_container :filterable do %>
       <%= label_tag :option_type_filterable do %>
         <%= f.check_box :filterable %>
         <%= Spree.t(:filterable) %>

--- a/app/views/spree/admin/orders/_channel_form.html.erb
+++ b/app/views/spree/admin/orders/_channel_form.html.erb
@@ -2,7 +2,7 @@
   <%= form_for [:admin, order], method: :put, url: set_channel_admin_order_url do |f| %>
     <fieldset>
     <div data-hook="admin_order_channel_field">
-      <%= f.field_container :channel, class: %w[form-group] do %>
+      <%= f.field_container :channel do %>
         <%= f.label :channel, Spree.t(:channel) %>
         <%= f.text_field :channel, name: 'channel', class: 'form-control' %>
         <%= f.error_message_on :channel %>

--- a/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/app/views/spree/admin/payment_methods/_form.html.erb
@@ -13,13 +13,13 @@
             <%= collection_select(:payment_method, :type, @providers, :to_s, :name, {}, {id: 'gtwy-type', class: 'select2'}) %>
           </div>
           <hr class="my-4">
-          <%= field_container :payment_method, :name, class: ['form-group'], 'data-hook' => 'name' do %>
+          <%= field_container :payment_method, :name, 'data-hook' => 'name' do %>
             <%= label_tag :payment_method_name, Spree.t(:name) %>
             <%= text_field :payment_method, :name, class: 'form-control' %>
             <%= error_message_on :payment_method, :name %>
           <% end %>
 
-          <%= field_container :payment_method, :description, class: ['form-group'], 'data-hook' => 'description' do %>
+          <%= field_container :payment_method, :description, 'data-hook' => 'description' do %>
             <%= label_tag :payment_method_description, Spree.t(:description) %>
             <%= text_area :payment_method, :description, { cols: 60, rows: 6, class: 'form-control' } %>
           <% end %>

--- a/app/views/spree/admin/products/_form.html.erb
+++ b/app/views/spree/admin/products/_form.html.erb
@@ -3,7 +3,7 @@
 
     <div class="col-12 col-md-8" data-hook="admin_product_form_left">
       <div data-hook="admin_product_form_name">
-        <%= f.field_container :name, class: ['form-group'] do %>
+        <%= f.field_container :name do %>
           <%= f.label :name, raw(Spree.t(:name) + required_span_tag) %>
           <%= f.text_field :name, class: 'form-control title' %>
           <%= f.error_message_on :name %>
@@ -11,7 +11,7 @@
       </div>
 
       <div data-hook="admin_product_form_slug">
-        <%= f.field_container :slug, class: ['form-group'] do %>
+        <%= f.field_container :slug do %>
           <%= f.label :slug, raw(Spree.t(:slug) + required_span_tag) %>
           <%= f.text_field :slug, class: 'form-control title' %>
           <%= f.error_message_on :slug %>
@@ -19,7 +19,7 @@
       </div>
 
       <div data-hook="admin_product_form_description">
-        <%= f.field_container :description, class: ['form-group'] do %>
+        <%= f.field_container :description do %>
           <%= f.label :description, Spree.t(:description) %>
           <%= f.text_area :description, { rows: "#{unless @product.has_variants? then '29' else '30' end}", class: "form-control #{"spree-rte" if product_wysiwyg_editor_enabled? }" } %>
           <%= f.error_message_on :description %>
@@ -29,7 +29,7 @@
 
     <div class="col-12 col-md-4" data-hook="admin_product_form_right">
       <div data-hook="admin_product_form_price">
-        <%= f.field_container :price, class: ['form-group'] do %>
+        <%= f.field_container :price do %>
           <%= f.label :price, raw(Spree.t(:master_price) + required_span_tag) %>
           <div class="input-group">
             <div class="input-group-prepend">
@@ -42,7 +42,7 @@
       </div>
 
       <div>
-        <%= f.field_container :compare_at_price, class: ['form-group'] do %>
+        <%= f.field_container :compare_at_price do %>
           <%= f.label :compare_at_price, Spree.t(:compare_at_price) %>
           <div class="input-group">
             <div class="input-group-prepend">
@@ -55,14 +55,14 @@
       </div>
 
       <div data-hook="admin_product_form_cost_price" class="alpha two columns">
-        <%= f.field_container :cost_price, class: ['form-group'] do %>
+        <%= f.field_container :cost_price do %>
           <%= f.label :cost_price, Spree.t(:cost_price) %>
           <%= f.text_field :cost_price, value: number_to_currency(@product.cost_price, unit: ''), class: 'form-control' %>
           <%= f.error_message_on :cost_price %>
         <% end %>
       </div>
       <div data-hook="admin_product_form_cost_currency" class="omega two columns">
-        <%= f.field_container :cost_currency, class: ['form-group'] do %>
+        <%= f.field_container :cost_currency do %>
           <%= f.label :cost_currency, Spree.t(:cost_currency) %>
           <%= f.select :cost_currency, currency_options(@product.cost_currency), {}, { class: 'select2' } %>
           <%= f.error_message_on :cost_currency %>
@@ -70,7 +70,7 @@
       </div>
 
       <div data-hook="admin_product_form_available_on">
-        <%= f.field_container :available_on, class: ['form-group'] do %>
+        <%= f.field_container :available_on do %>
           <%= f.label :available_on, Spree.t(:available_on) %>
           <%= f.error_message_on :available_on %>
 
@@ -91,7 +91,7 @@
       </div>
 
       <div data-hook="admin_product_form_discontinue_on">
-        <%= f.field_container :discontinue_on, class: ['form-group'] do %>
+        <%= f.field_container :discontinue_on do %>
           <%= f.label :discontinue_on, Spree.t(:discontinue_on) %>
           <%= f.error_message_on :discontinue_on %>
 
@@ -112,7 +112,7 @@
       </div>
 
       <div data-hook="admin_product_form_promotionable">
-        <%= f.field_container :promotionable, class: ['form-group'] do %>
+        <%= f.field_container :promotionable do %>
           <%= f.check_box :promotionable %>
           <%= f.label :promotionable, Spree.t(:promotionable) %>
           <%= f.error_message_on :promotionable %>
@@ -120,7 +120,7 @@
       </div>
 
       <div data-hook="admin_product_form_sku">
-        <%= f.field_container :master_sku, class: ['form-group'] do %>
+        <%= f.field_container :master_sku do %>
           <%= f.label :master_sku, Spree.t(:master_sku) %>
           <%= f.text_field :sku, size: 16, class: 'form-control' %>
         <% end %>
@@ -181,7 +181,7 @@
       <% end %>
 
       <div data-hook="admin_product_form_shipping_categories">
-        <%= f.field_container :shipping_category, class: ['form-group'] do %>
+        <%= f.field_container :shipping_category do %>
           <%= f.label :shipping_category_id, Spree.t(:shipping_category) %>
           <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { include_blank: Spree.t('match_choices.none') }, { class: 'select2' }) %>
           <%= f.error_message_on :shipping_category %>
@@ -189,7 +189,7 @@
       </div>
 
       <div data-hook="admin_product_form_tax_category">
-        <%= f.field_container :tax_category, class: ['form-group'] do %>
+        <%= f.field_container :tax_category do %>
           <%= f.label :tax_category_id, Spree.t(:tax_category) %>
           <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { include_blank: Spree.t('match_choices.none') }, { class: 'select2' }) %>
           <%= f.error_message_on :tax_category %>
@@ -200,7 +200,7 @@
   </div>
 
   <div data-hook="admin_product_form_taxons">
-    <%= f.field_container :taxons, class: ['form-group'] do %>
+    <%= f.field_container :taxons do %>
       <%= f.label :taxon_ids, Spree.t(:taxons) %>
 
       <% if can? :modify, Spree::Classification %>
@@ -224,7 +224,7 @@
   </div>
 
   <div data-hook="admin_product_form_option_types">
-    <%= f.field_container :option_types, class: ['form-group'] do %>
+    <%= f.field_container :option_types do %>
       <%= f.label :option_type_ids, Spree.t(:option_types) %>
 
       <% if can? :modify, Spree::ProductOptionType %>
@@ -250,7 +250,7 @@
 
   <% if @stores.count > 1 %>
     <div data-hook="admin_product_form_stores">
-      <%= f.field_container :stores, class: ['form-group'] do %>
+      <%= f.field_container :stores do %>
         <%= f.label :product_stores, Spree.t(:stores) %>
         <%= collection_select(:product, :store_ids, @stores, :id, :unique_name, {}, { multiple: true, class: 'select2' }) %>
       <% end %>
@@ -259,21 +259,21 @@
 
   <div data-hook="admin_product_form_meta">
     <div data-hook="admin_product_form_meta_title">
-      <%= f.field_container :meta_title, class: ['form-group'] do %>
+      <%= f.field_container :meta_title do %>
         <%= f.label :meta_title, Spree.t(:meta_title) %>
         <%= f.text_field :meta_title, class: 'form-control' %>
       <% end %>
     </div>
 
     <div data-hook="admin_product_form_meta_keywords">
-      <%= f.field_container :meta_keywords, class: ['form-group'] do %>
+      <%= f.field_container :meta_keywords do %>
         <%= f.label :meta_keywords, Spree.t(:meta_keywords) %>
         <%= f.text_field :meta_keywords, class: 'form-control' %>
       <% end %>
     </div>
 
     <div data-hook="admin_product_form_meta_description">
-      <%= f.field_container :meta_description, class: ['form-group'] do %>
+      <%= f.field_container :meta_description do %>
         <%= f.label :meta_description, Spree.t(:meta_description) %>
         <%= f.text_area :meta_description, class: 'form-control' %>
       <% end %>

--- a/app/views/spree/admin/products/new.html.erb
+++ b/app/views/spree/admin/products/new.html.erb
@@ -7,7 +7,7 @@
 
 <%= form_for [:admin, @product], html: { multipart: true } do |f| %>
   <fieldset data-hook="new_product">
-    <%= f.field_container :name, class: ['form-group'] do %>
+    <%= f.field_container :name do %>
       <%= f.label :name, Spree.t(:name) %> <span class="required">*</span>
       <%= f.text_field :name, class: 'form-control title', required: :required %>
       <%= f.error_message_on :name %>
@@ -16,7 +16,7 @@
     <div data-hook="new_product_attrs" class="row">
       <% unless @product.has_variants? %>
         <div data-hook="new_product_sku" class="col-12 col-md-4">
-          <%= f.field_container :sku, class: ['form-group'] do %>
+          <%= f.field_container :sku do %>
             <%= f.label :sku, Spree.t(:sku) %>
             <%= f.text_field :sku, size: 16, class: 'form-control' %>
             <%= f.error_message_on :sku %>
@@ -25,14 +25,14 @@
       <% end %>
 
       <div data-hook="new_product_prototype" class="col-12 col-md-4">
-        <%= f.field_container :prototype, class: ['form-group'] do %>
+        <%= f.field_container :prototype do %>
           <%= f.label :prototype_id, Spree.t(:prototype) %>
           <%= f.collection_select :prototype_id, Spree::Prototype.all, :id, :name, { include_blank: true }, { class: 'select2-clear w-100' } %>
         <% end %>
       </div>
 
       <div data-hook="new_product_price" class="col-12 col-md-4">
-        <%= f.field_container :price, class: ['form-group'] do %>
+        <%= f.field_container :price do %>
         <%= f.label :price, Spree.t(:master_price) %> <span class="required">*</span>
         <div class="input-group">
           <div class="input-group-prepend">
@@ -45,7 +45,7 @@
       </div>
 
       <div data-hook="new_product_available_on" class="col-12 col-md-4">
-        <%= f.field_container :available_on, class: ['form-group'] do %>
+        <%= f.field_container :available_on do %>
           <%= f.label :available_on, Spree.t(:available_on) %>
           <%= f.error_message_on :available_on %>
 
@@ -64,7 +64,7 @@
       </div>
 
       <div data-hook="new_product_shipping_category" class="col-12 col-md-4">
-        <%= f.field_container :shipping_category, class: ['form-group'] do %>
+        <%= f.field_container :shipping_category do %>
           <%= f.label :shipping_category_id, Spree.t(:shipping_categories) %><span class="required">*</span>
           <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { include_blank: Spree.t('match_choices.none') }, { class: 'select2 w-100' }) %>
           <%= f.error_message_on :shipping_category_id %>

--- a/app/views/spree/admin/promotion_categories/_form.html.erb
+++ b/app/views/spree/admin/promotion_categories/_form.html.erb
@@ -1,11 +1,11 @@
 <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @promotion_category } %>
 
-<%= f.field_container :name, class: ['form-group'] do %>
+<%= f.field_container :name do %>
   <%= f.label :name %>
   <%= f.text_field :name, class: 'form-control' %>
   <%= f.error_message_on :name %>
 <% end %>
-<%= f.field_container :code, class: ['form-group'] do %>
+<%= f.field_container :code do %>
   <%= f.label :code %>
   <%= f.text_field :code, class: 'form-control' %>
 <% end %>

--- a/app/views/spree/admin/promotions/_form.html.erb
+++ b/app/views/spree/admin/promotions/_form.html.erb
@@ -2,7 +2,7 @@
 
 <div class="row" id="general_fields">
   <div class="col-12 col-lg-4">
-    <%= f.field_container :name, class: ['form-group'] do %>
+    <%= f.field_container :name do %>
       <%= f.label :name %>
       <%= f.text_field :name, class: 'form-control' %>
       <%= f.error_message_on :name %>
@@ -22,7 +22,7 @@
       <% end %>
     </div>
 
-    <%= f.field_container :path, class: ['form-group'] do %>
+    <%= f.field_container :path do %>
       <%= f.label :path %>
       <%= f.text_field :path, class: 'form-control' %>
     <% end %>
@@ -36,18 +36,18 @@
   </div>
 
   <div class="col-12 col-lg-4">
-    <%= f.field_container :description, class: ['form-group'] do %>
+    <%= f.field_container :description do %>
       <%= f.label :description %>
       <%= f.text_area :description, rows: 7, class: 'form-control' %>
     <% end %>
 
-    <%= f.field_container :category, class: ['form-group'] do %>
+    <%= f.field_container :category do %>
       <%= f.label :promotion_category %>
       <%= f.collection_select(:promotion_category_id, @promotion_categories, :id, :name, { include_blank: Spree.t('match_choices.none') }, { class: 'select2 w-100' }) %>
     <% end %>
 
     <% if @stores.count > 1 %>
-      <%= f.field_container :stores, class: ['form-group'] do %>
+      <%= f.field_container :stores do %>
         <%= f.label :promotion_stores, Spree.t(:stores) %>
         <%= collection_select(:promotion, :store_ids, @stores, :id, :unique_name, {}, { multiple: true, class: 'select2' }) %>
       <% end %>

--- a/app/views/spree/admin/properties/_form.html.erb
+++ b/app/views/spree/admin/properties/_form.html.erb
@@ -1,20 +1,20 @@
 <div data-hook="admin_property_form" class="row">
   <div class="col-12 col-md-6">
-    <%= f.field_container :name, class: ['form-group'] do %>
+    <%= f.field_container :name do %>
       <%= f.label :name, Spree.t(:name) %> <span class="required">*</span>
       <%= f.text_field :name, class: 'form-control' %>
       <%= f.error_message_on :name %>
     <% end %>
   </div>
   <div class="col-12 col-md-6">
-    <%= f.field_container :presentation, class: ['form-group'] do %>
+    <%= f.field_container :presentation do %>
       <%= f.label :presentation, Spree.t(:presentation) %> <span class="required">*</span>
       <%= f.text_field :presentation, class: 'form-control' %>
       <%= f.error_message_on :presentation %>
     <% end %>
   </div>
   <div class="col-12 col-md-6">
-    <%= f.field_container :filterable, class: ['form-group'] do %>
+    <%= f.field_container :filterable do %>
       <%= f.label :filterable, Spree.t(:filterable) %>
       <%= f.check_box :filterable %>
     <% end %>

--- a/app/views/spree/admin/prototypes/_form.html.erb
+++ b/app/views/spree/admin/prototypes/_form.html.erb
@@ -1,26 +1,26 @@
 <div data-hook="admin_prototype_form_fields">
-  <%= f.field_container :name, class: ['form-group'] do %>
+  <%= f.field_container :name do %>
     <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br>
     <%= f.text_field :name, class: 'form-control' %>
     <%= f.error_message_on :name %>
   <% end %>
 
   <div id='properties' data-hook>
-    <%= f.field_container :property_ids, class: ['form-group'] do %>
+    <%= f.field_container :property_ids do %>
       <%= f.label :property_ids, Spree.t(:properties) %><br>
       <%= f.select :property_ids, Spree::Property.all.map { |p| ["#{p.presentation} (#{p.name})", p.id] }, {}, { multiple: true, class: "select2" } %>
     <% end %>
   </div>
 
   <div id="option_types" data-hook>
-    <%= f.field_container :option_type_ids, class: ['form-group'] do %>
+    <%= f.field_container :option_type_ids do %>
       <%= f.label :option_type_ids, Spree.t(:option_types) %><br>
       <%= f.select :option_type_ids, Spree::OptionType.all.map { |ot| ["#{ot.presentation} (#{ot.name})", ot.id] }, {}, { multiple: true, class: "select2" } %>
     <% end %>
   </div>
 
   <div id='taxons' data-hook>
-    <%= f.field_container :taxon_ids, class: ['form-group'] do %>
+    <%= f.field_container :taxon_ids do %>
       <%= f.label :taxon_ids, Spree.t(:taxons) %><br>
       <%= f.select :taxon_ids, current_store.taxons.pluck(:name, :id), {}, { multiple: true, class: "select2" } %>
     <% end %>

--- a/app/views/spree/admin/refunds/new.html.erb
+++ b/app/views/spree/admin/refunds/new.html.erb
@@ -18,12 +18,12 @@
         <%= f.label :credit_allowed, Spree.t(:credit_allowed) %><br>
         <%= @refund.payment.credit_allowed %>
       </div>
-      <%= f.field_container :amount, class: ['form-group'] do %>
+      <%= f.field_container :amount do %>
         <%= f.label :amount, Spree.t(:amount) %>
         <%= f.text_field :amount, class: 'form-control' %>
         <%= f.error_message_on :amount %>
       <% end %>
-      <%= f.field_container :reason, class: ['form-group'] do %>
+      <%= f.field_container :reason do %>
         <%= f.label :refund_reason_id, Spree.t(:reason) %>
         <%= f.collection_select(:refund_reason_id, refund_reasons, :id, :name, {include_blank: true}, {class: 'select2-clear'}) %>
         <%= f.error_message_on :reason %>

--- a/app/views/spree/admin/reimbursement_types/_form.html.erb
+++ b/app/views/spree/admin/reimbursement_types/_form.html.erb
@@ -1,6 +1,6 @@
 <div data-hook="admin_reimbursement_type_form_fields" class="row">
   <div class="col-12 col-md-8">
-    <%= f.field_container :name, class: ['form-group'] do %>
+    <%= f.field_container :name do %>
       <%= f.label :name, Spree.t(:name) %>
       <%= f.text_field :name, class:'form-control' %>
       <%= f.error_message_on :name %>
@@ -8,7 +8,7 @@
   </div>
   <%- if @reimbursement_type.new_record? %>
     <div class="col-12 col-md-8">
-      <%= f.field_container :type, class: ['form-group'] do %>
+      <%= f.field_container :type do %>
         <%= f.label :type, Spree.t(:type) %>
         <%= f.select :type, options_for_select(Spree::ReimbursementType::KINDS), {:include_blank => false}, { :class => 'select2' } %>
         <%= f.error_message_on :type %>

--- a/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -82,19 +82,19 @@
     <%= Spree.t(:total_pre_tax_refund) %>: <span id="total_pre_tax_refund">0.00</span>
   <% end %>
 
-  <%= f.field_container :stock_location, class: ['form-group'] do %>
+  <%= f.field_container :stock_location do %>
     <%= f.label :stock_location, Spree.t(:stock_location) %> <span class="required">*</span>
     <%= f.select :stock_location_id, Spree::StockLocation.order_default.active.to_a.collect{|l|[l.name, l.id]}, {include_blank: true}, {class: 'select2-clear', "data-placeholder" => Spree.t(:select_a_stock_location)} %>
     <%= f.error_message_on :stock_location %>
   <% end %>
 
-  <%= f.field_container :reason, class: ['form-group'] do %>
+  <%= f.field_container :reason do %>
     <%= f.label :reason, Spree.t(:reason) %> <span class="required">*</span>
     <%= f.select :return_authorization_reason_id, @reasons.collect{|r|[r.name, r.id]}, {include_blank: true}, {class: 'select2-clear', "data-placeholder" => Spree.t(:select_a_return_authorization_reason)} %>
     <%= f.error_message_on :reason %>
   <% end %>
 
-  <%= f.field_container :memo, class: ['form-group'] do %>
+  <%= f.field_container :memo do %>
     <%= f.label :memo, Spree.t(:memo) %>
     <%= f.text_area :memo, class: 'form-control' %>
     <%= f.error_message_on :memo %>

--- a/app/views/spree/admin/roles/_form.html.erb
+++ b/app/views/spree/admin/roles/_form.html.erb
@@ -1,5 +1,5 @@
 <div data-hook="admin_role_form_fields">
-  <%= f.field_container :name, class: ["form-group"], 'data-hook' => "role_name" do %>
+  <%= f.field_container :name, 'data-hook' => "role_name" do %>
     <%= f.label :name, Spree.t(:name) %> <span class="required">*</span>
     <%= f.text_field :name, class: 'form-control' %>
     <%= f.error_message_on :name %>

--- a/app/views/spree/admin/shared/_address_form.html.erb
+++ b/app/views/spree/admin/shared/_address_form.html.erb
@@ -2,14 +2,14 @@
 <div id="<%= type %>" data-hook="address_fields">
   <% Spree::Address::ADDRESS_FIELDS.each do |field| %>
     <% if field == "country" %>
-      <%= field_container (s_or_b + '_' + field), nil, class: ["form-group", "#{type}-row"] do %>
+      <%= field_container (s_or_b + '_' + field), nil, class: ["#{type}-row"] do %>
         <%= f.label :country_id, Spree.t(:country) %>
         <div id="<%= s_or_b %>country">
           <%= f.collection_select :country_id, all_countries, :id, :name, {}, { class: 'select2 w-100' } %>
         </div>
       <% end %>
     <% elsif field == "state" %>
-      <%= field_container (s_or_b + '_' + field), :state, class: ["form-group", "#{type}-row"] do %>
+      <%= field_container (s_or_b + '_' + field), :state, class: ["#{type}-row"] do %>
         <%= f.label :state_id, Spree.t(:state) %>
         <div id="<%= s_or_b %>state">
           <% if f.object.country.try(:states) %>
@@ -26,7 +26,7 @@
         <%= error_message_on f.object, :state_id %>
       <% end %>
     <% else %>
-      <%= field_container (s_or_b + '_' + field), nil, class: ["form-group", "#{type}-row"] do %>
+      <%= field_container (s_or_b + '_' + field), nil, class: ["#{type}-row"] do %>
         <%= f.label field, Spree.t(field) %>
         <%= f.text_field field, class: 'form-control' %>
         <%= error_message_on f.object, field %>

--- a/app/views/spree/admin/shared/cms/_spree_product.html.erb
+++ b/app/views/spree/admin/shared/cms/_spree_product.html.erb
@@ -1,4 +1,4 @@
-<%= f.field_container save_to, class: ['form-group'] do %>
+<%= f.field_container save_to do %>
   <%= f.label save_to, Spree.t('admin.cms.link_to_product') %>
   <%= f.select save_to, options_from_collection_for_select([resource], save_to, save_to, resource.send(save_to) || nil), { include_blank: true },
                           id: "cms_section_#{save_to}",

--- a/app/views/spree/admin/shared/cms/_spree_taxon.html.erb
+++ b/app/views/spree/admin/shared/cms/_spree_taxon.html.erb
@@ -1,4 +1,4 @@
-<%= f.field_container save_to, class: ['form-group'] do %>
+<%= f.field_container save_to do %>
   <%= f.label save_to, Spree.t('admin.cms.link_to_taxon') %>
   <%= f.select save_to, options_from_collection_for_select([resource], save_to, save_to, resource.send(save_to) || nil), { include_blank: true },
                           id: "cms_section_#{save_to}",

--- a/app/views/spree/admin/shared/linkables/_spree_cms_page.erb
+++ b/app/views/spree/admin/shared/linkables/_spree_cms_page.erb
@@ -4,7 +4,7 @@
    <% name_holder = :title %>
    <% active_id_holder = resource.linked_resource.id %>
  <% end %>
- <%= f.field_container :linked_resource_id, class: ['form-group'] do %>
+ <%= f.field_container :linked_resource_id do %>
     <%= f.label :linked_resource_id, Spree.t('page') %>
     <%= f.select :linked_resource_id,
          options_from_collection_for_select(resorce_holder || [],

--- a/app/views/spree/admin/shared/linkables/_spree_product.html.erb
+++ b/app/views/spree/admin/shared/linkables/_spree_product.html.erb
@@ -4,7 +4,7 @@
    <% name_holder = :name %>
    <% active_id_holder = resource.linked_resource.id %>
  <% end %>
- <%= f.field_container :linked_resource_id, class: ['form-group'] do %>
+ <%= f.field_container :linked_resource_id do %>
     <%= f.label :linked_resource_id, Spree.t('product') %>
     <%= f.select :linked_resource_id,
          options_from_collection_for_select(resorce_holder || [],

--- a/app/views/spree/admin/shared/linkables/_spree_taxon.html.erb
+++ b/app/views/spree/admin/shared/linkables/_spree_taxon.html.erb
@@ -5,7 +5,7 @@
    <% active_id_holder = resource.linked_resource.id %>
  <% end %>
 
- <%= f.field_container :linked_resource_field, class: ['form-group'] do %>
+ <%= f.field_container :linked_resource_field do %>
    <%= f.label :linked_resource_id, Spree.t('taxon') %>
    <%= f.select :linked_resource_id,
         options_from_collection_for_select(resource_holder || [],

--- a/app/views/spree/admin/shared/linkables/_url.html.erb
+++ b/app/views/spree/admin/shared/linkables/_url.html.erb
@@ -1,4 +1,4 @@
-<%= f.field_container :destination, class: ['form-group'] do %>
+<%= f.field_container :destination do %>
   <%= f.label :destination, Spree.t(:url) %>
   <%= f.text_field :destination, class: 'form-control' %>
   <%= f.error_message_on :destination %>

--- a/app/views/spree/admin/shared/named_types/_form.html.erb
+++ b/app/views/spree/admin/shared/named_types/_form.html.erb
@@ -1,5 +1,5 @@
 <div data-hook="admin_named_type_form_fields">
-  <%= f.field_container :name, class: ['form-group'] do %>
+  <%= f.field_container :name do %>
     <%= f.label :name, Spree.t(:name) %> <span class="required">*</span>
     <%= f.text_field :name, class: 'form-control' %>
     <%= f.error_message_on :name %>

--- a/app/views/spree/admin/shipping_categories/_form.html.erb
+++ b/app/views/spree/admin/shipping_categories/_form.html.erb
@@ -1,6 +1,6 @@
 <div data-hook="admin_shipping_category_form_fields">
   <div data-hook="name" class="form-group">
-    <%= f.field_container :name, class: ["form-group"] do %>
+    <%= f.field_container :name do %>
       <%= f.label :name, Spree.t(:name) %><br>
       <%= f.text_field :name, class: 'form-control' %>
       <%= f.error_message_on :name %>

--- a/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -1,7 +1,7 @@
 <div data-hook="admin_shipping_method_form_fields">
   <div class="row">
     <div data-hook="admin_shipping_method_form_name_field" class="col-12 col-lg-6">
-      <%= f.field_container :name, class: ['form-group'] do %>
+      <%= f.field_container :name do %>
         <%= f.label :name, Spree.t(:name) %>
         <%= f.text_field :name, class: 'form-control' %>
         <%= f.error_message_on :name %>
@@ -9,7 +9,7 @@
     </div>
 
     <div data-hook="admin_shipping_method_form_display_field" class="col-12 col-lg-6">
-      <%= f.field_container :display_on, class: ['form-group'] do %>
+      <%= f.field_container :display_on do %>
         <%= f.label :display_on, Spree.t(:display) %>
         <%= select(:shipping_method, :display_on, Spree::ShippingMethod::DISPLAY.collect { |display| [Spree.t(display), display.to_s] }, { include_blank: true }, { class: 'select2-clear' }) %>
         <%= f.error_message_on :display_on %>
@@ -19,7 +19,7 @@
 
   <div class="row">
     <div data-hook="admin_shipping_method_form_internal_name_field" class="col-12 col-lg-4">
-      <%= f.field_container :admin_name, class: ['form-group'] do %>
+      <%= f.field_container :admin_name do %>
         <%= f.label :admin_name, Spree.t(:internal_name) %>
         <%= f.text_field :admin_name, class: 'form-control', label: false %>
         <%= f.error_message_on :admin_name %>
@@ -27,7 +27,7 @@
     </div>
 
     <div data-hook="admin_shipping_method_form_code" class="col-12 col-lg-4">
-      <%= f.field_container :code, class: ['form-group'] do %>
+      <%= f.field_container :code do %>
         <%= f.label :code, Spree.t(:code) %>
         <%= f.text_field :code, class: 'form-control', label: false %>
         <%= f.error_message_on :code %>
@@ -35,7 +35,7 @@
     </div>
 
     <div data-hook="admin_shipping_method_form_tracking_url_field" class="col-12 col-lg-4">
-      <%= f.field_container :tracking_url, class: ['form-group'] do %>
+      <%= f.field_container :tracking_url do %>
         <%= f.label :tracking_url, Spree.t(:tracking_url) %>
         <%= f.text_field :tracking_url, class: 'form-control', placeholder: Spree.t(:tracking_url_placeholder) %>
         <%= f.error_message_on :tracking_url %>
@@ -54,7 +54,7 @@
       </div>
 
       <div class="card-body">
-        <%= f.field_container :categories, class: ['form-group'] do %>
+        <%= f.field_container :categories do %>
           <% Spree::ShippingCategory.all.each do |category| %>
             <div class="checkbox">
               <%= label_tag do %>
@@ -78,7 +78,7 @@
       </div>
 
       <div class="card-body">
-        <%= f.field_container :zones, class: ['form-group'] do %>
+        <%= f.field_container :zones do %>
           <% shipping_method_zones = @shipping_method.zones.to_a %>
           <% Spree::Zone.all.each do |zone| %>
             <div class="checkbox">
@@ -109,7 +109,7 @@
       </div>
 
       <div class="card-body">
-        <%= f.field_container :categories, class: ['form-group'] do %>
+        <%= f.field_container :categories do %>
           <%= f.select :tax_category_id, @tax_categories.map { |tc| [tc.name, tc.id] }, { include_blank: true }, class: "select2-clear" %>
           <%= f.error_message_on :tax_category_id %>
         <% end %>

--- a/app/views/spree/admin/states/_form.html.erb
+++ b/app/views/spree/admin/states/_form.html.erb
@@ -1,13 +1,13 @@
 <div data-hook="admin_state_form_fields" class="row">
   <div class="col-12 col-md-6">
-    <%= f.field_container :name, class: ['form-group'] do %>
+    <%= f.field_container :name do %>
       <%= f.label :name, Spree.t(:name) %>
       <%= f.text_field :name, class: 'form-control' %>
       <%= f.error_message_on :name %>
     <% end %>
   </div>
   <div class="col-12 col-md-6">
-    <%= f.field_container :abbr, class: ['form-group'] do %>
+    <%= f.field_container :abbr do %>
       <%= f.label :abbr, Spree.t(:abbreviation) %>
       <%= f.text_field :abbr, class: 'form-control' %>
     <% end %>

--- a/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/app/views/spree/admin/stock_locations/_form.html.erb
@@ -2,14 +2,14 @@
   <div class="row">
     <div class="col-12 col-md-9" data-hook="stock_location_names">
       <div data-hook="stock_location_name">
-        <%= f.field_container :name, class: ['form-group']  do %>
+        <%= f.field_container :name  do %>
           <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br>
           <%= f.text_field :name, class: 'form-control', required: true %>
           <%= f.error_message_on :name %>
         <% end %>
       </div>
       <div data-hook="stock_location_admin_name">
-        <%= f.field_container :admin_name, class: ['form-group']  do %>
+        <%= f.field_container :admin_name  do %>
         <%= f.label :admin_name, Spree.t(:internal_name) %>
         <%= f.text_field :admin_name, class: 'form-control', label: false %>
         <% end %>

--- a/app/views/spree/admin/stock_movements/_form.html.erb
+++ b/app/views/spree/admin/stock_movements/_form.html.erb
@@ -1,9 +1,9 @@
 <div data-hook="admin_stock_movements_form_fields">
-  <%= f.field_container :quantity, class: ['form-group'] do %>
+  <%= f.field_container :quantity do %>
     <%= f.label :quantity, Spree.t(:quantity) %>
     <%= f.text_field :quantity, class: 'form-control' %>
   <% end %>
-  <%= f.field_container :stock_item_id, class: ['form-group'] do %>
+  <%= f.field_container :stock_item_id do %>
     <%= f.label :stock_item_id, Spree.t(:stock_item_id) %>
     <%= select_tag 'stock_movement[stock_item_id]', nil , class: 'variant_autocomplete d-block w-100', :'data-stock-location-id' => params[:stock_location_id] %>
   <% end %>

--- a/app/views/spree/admin/store_credit_categories/_form.html.erb
+++ b/app/views/spree/admin/store_credit_categories/_form.html.erb
@@ -1,5 +1,5 @@
 <div data-hook="admin_store_credit_category_form_fields">
-  <%= f.field_container :name, class: ['form-group'], 'data-hook' => 'store_credit_category_name' do %>
+  <%= f.field_container :name, 'data-hook' => 'store_credit_category_name' do %>
     <%= f.label :name, Spree.t(:name) %> <span class="required">*</span>
     <%= f.text_field :name, class: 'form-control' %>
     <%= f.error_message_on :name %>

--- a/app/views/spree/admin/store_credits/_form.html.erb
+++ b/app/views/spree/admin/store_credits/_form.html.erb
@@ -1,21 +1,21 @@
 <div data-hook='admin_store_credit_form_fields'>
-  <%= f.field_container :amount, class: %w[form-group] do %>
+  <%= f.field_container :amount do %>
     <%= f.label :amount, raw(Spree.t(:amount) + required_span_tag) %>
     <%= f.text_field :amount, class: 'form-control' %>
     <%= f.error_message_on :amount %>
   <% end %>
-  <%= f.field_container :currency, class: %w[form-group] do %>
+  <%= f.field_container :currency do %>
     <%= f.label :currency, raw(Spree.t(:currency) + required_span_tag) %>
     <%= f.select :currency, currency_options(f.object.currency) %>
     <%= f.error_message_on :currency %>
   <% end %>
-  <%= f.field_container :category, class: %w[form-group] do %>
+  <%= f.field_container :category do %>
     <%= f.label :category, raw(Spree.t(:category) + required_span_tag) %>
     <%= f.select :category_id, options_from_collection_for_select(@credit_categories, :id, :name, f.object.category.try(:id)),
         { include_blank: true }, { class: 'select2 fullwidth', placeholder: Spree.t(:select_a_store_credit_reason) } %>
     <%= f.error_message_on :category %>
   <% end %>
-  <%= f.field_container :memo, class: %w[form-group] do %>
+  <%= f.field_container :memo do %>
     <%= f.label :memo, Spree.t(:memo) %>
     <%= f.text_area :memo, class: 'form-control' %>
     <%= f.error_message_on :memo %>

--- a/app/views/spree/admin/stores/_form.html.erb
+++ b/app/views/spree/admin/stores/_form.html.erb
@@ -7,44 +7,44 @@
     </h1>
   </div>
   <div class="card-body">
-    <%= f.field_container :logo, class: ['form-group'] do %>
+    <%= f.field_container :logo do %>
       <% if @store.logo.attached? && @store.logo.variable? %>
         <%= image_tag main_app.url_for(@store.logo.variant(resize: '244x104>')) %>
       <% elsif @store.logo.attached? && @store.logo.image? %>
         <%= image_tag main_app.url_for(@store.logo) %>
       <% end %>
-      <%= f.field_container :logo, class: ['form-group'] do %>
+      <%= f.field_container :logo do %>
         <%= f.label :logo, Spree.t(:logo) %><br>
         <%= f.file_field :logo %>
         <%= f.error_message_on :logo %>
       <% end %>
     <% end %>
-    <%= f.field_container :mailer_logo, class: ['form-group'] do %>
+    <%= f.field_container :mailer_logo do %>
       <% if @store.mailer_logo.attached? && @store.mailer_logo.variable? %>
         <%= image_tag main_app.url_for(@store.mailer_logo.variant(resize: '244x104>')) %>
       <% end %>
-      <%= f.field_container :mailer_logo, class: ['form-group'] do %>
+      <%= f.field_container :mailer_logo do %>
         <%= f.label :mailer_logo, Spree.t(:mailer_logo) %><br>
         <%= f.file_field :mailer_logo, accept: Spree::Store::MAILER_LOGO_CONTENT_TYPES.join(',') %>
         <%= f.error_message_on :mailer_logo %>
       <% end %>
     <% end %>
-    <%= f.field_container :favicon_image, class: ['form-group'] do %>
+    <%= f.field_container :favicon_image do %>
       <% if @store.favicon_image.attached? && @store.favicon_image.variable? %>
         <%= image_tag main_app.url_for(@store.favicon_image.variant(resize: '104x104')) %>
       <% end %>
-      <%= f.field_container :favicon_image, class: ['form-group'] do %>
+      <%= f.field_container :favicon_image do %>
         <%= f.label :favicon_image, "#{Spree.t(:favicon)} (#{Spree.t(:favicon_upload_info)})" %><br>
         <%= f.file_field :favicon_image, accept: Spree::Store::FAVICON_CONTENT_TYPES.join(',') %>
         <%= f.error_message_on :favicon_image %>
       <% end %>
     <% end %>
-    <%= f.field_container :name, class: ['form-group'] do %>
+    <%= f.field_container :name do %>
       <%= f.label :name, raw(Spree.t(:name) + required_span_tag) %>
       <%= f.text_field :name, class: 'form-control', required: true %>
       <%= f.error_message_on :name %>
     <% end %>
-    <%= f.field_container :code, class: ['form-group'] do %>
+    <%= f.field_container :code do %>
       <%= f.label :code, raw(Spree.t(:code) + required_span_tag) %>
       <%= f.text_field :code, class: 'form-control', required: true %>
       <small class="form-text text-muted">
@@ -52,7 +52,7 @@
       </small>
       <%= f.error_message_on :code %>
     <% end %>
-    <%= f.field_container :url, class: ['form-group'] do %>
+    <%= f.field_container :url do %>
       <%= f.label :url, raw(Spree.t(:url) + required_span_tag) %>
       <div class="input-group mb-3">
         <div class="input-group-prepend">
@@ -72,22 +72,22 @@
     </h1>
   </div>
   <div class="card-body">
-    <%= f.field_container :seo_title, class: ['form-group'] do %>
+    <%= f.field_container :seo_title do %>
       <%= f.label :seo_title, Spree.t(:seo_title) %>
       <%= f.text_field :seo_title, class: 'form-control' %>
       <%= f.error_message_on :seo_title %>
     <% end %>
-    <%= f.field_container :meta_description, class: ['form-group'] do %>
+    <%= f.field_container :meta_description do %>
       <%= f.label :meta_description, Spree.t(:meta_description) %>
       <%= f.text_area :meta_description, class: 'form-control' %>
       <%= f.error_message_on :meta_description %>
     <% end %>
-    <%= f.field_container :meta_keywords, class: ['form-group'] do %>
+    <%= f.field_container :meta_keywords do %>
       <%= f.label :meta_keywords, Spree.t(:meta_keywords) %>
       <%= f.text_field :meta_keywords, class: 'form-control' %>
       <%= f.error_message_on :meta_keywords %>
     <% end %>
-    <%= f.field_container :seo_robots, class:['form-group']  do %>
+    <%= f.field_container :seo_robots do %>
       <%= f.label :seo_robots, Spree.t(:seo_robots) %>
       <%= f.text_field :seo_robots, class: 'form-control' %>
       <%= f.error_message_on :seo_robots %>
@@ -105,7 +105,7 @@
     </h1>
   </div>
   <div class="card-body">
-    <%= f.field_container :mail_from_address, class: ['form-group'] do %>
+    <%= f.field_container :mail_from_address do %>
       <%= f.label :mail_from_address, raw(Spree.t(:mail_from_address)  + required_span_tag) %>
       <%= f.text_field :mail_from_address, class: 'form-control', required: true %>
       <%= f.error_message_on :mail_from_address %>
@@ -114,7 +114,7 @@
       </small>
     <% end %>
 
-    <%= f.field_container :customer_support_email, class: ['form-group'] do %>
+    <%= f.field_container :customer_support_email do %>
       <%= f.label :customer_support_email, Spree.t(:customer_support_email) %>
       <%= f.text_field :customer_support_email, class: 'form-control' %>
       <%= f.error_message_on :customer_support_email %>
@@ -123,7 +123,7 @@
       </small>
     <% end %>
 
-    <%= f.field_container :new_order_notifications_email, class: ['form-group'] do %>
+    <%= f.field_container :new_order_notifications_email do %>
       <%= f.label :new_order_notifications_email, Spree.t(:new_order_notifications_email) %>
       <%= f.text_field :new_order_notifications_email, class: 'form-control' %>
       <%= f.error_message_on :new_order_notifications_email %>
@@ -141,17 +141,17 @@
     </h1>
   </div>
   <div class="card-body">
-    <%= f.field_container :default_currency, class: ['form-group'] do %>
+    <%= f.field_container :default_currency do %>
       <%= f.label :default_currency %>
       <%= f.select :default_currency, currency_options(@store.default_currency), {}, { class: 'select2' } %>
       <%= f.error_message_on :default_currency %>
     <% end %>
-    <%= f.field_container :supported_currencies, class: ['form-group'] do %>
+    <%= f.field_container :supported_currencies do %>
       <%= f.label :supported_currencies, Spree.t(:supported_currencies) %>
       <%= f.select :supported_currencies, currency_options(@store.supported_currencies&.split(',')), { prompt: false }, { multiple: true, class: 'select2' } %>
       <%= f.error_message_on :supported_currencies %>
     <% end %>
-    <%= f.field_container :checkout_zone_id, class: ['form-group'] do %>
+    <%= f.field_container :checkout_zone_id do %>
       <%= f.label :checkout_zone_id, Spree.t(:zone) %>
       <%= f.select :checkout_zone_id, options_for_select(@zones, selected_checkout_zone(@store)&.id), { include_blank: Spree.t(:no_limits_zone) }, { class: 'select2' } %>
       <small class="form-text text-muted">
@@ -159,7 +159,7 @@
       </small>
       <%= f.error_message_on :checkout_zone_id %>
     <% end %>
-    <%= f.field_container :default_locale, class: ['form-group'] do %>
+    <%= f.field_container :default_locale do %>
       <%= f.label :default_locale %>
       <%= f.select :default_locale, options_from_collection_for_select(all_locales_options, :last, :first, @store.default_locale || I18n.locale), {}, { class: 'select2' } %>
       <%= f.error_message_on :default_locale %>
@@ -169,12 +169,12 @@
         </small>
       <% end %>
     <% end %>
-    <%= f.field_container :supported_locales, class: ['form-group'] do %>
+    <%= f.field_container :supported_locales do %>
       <%= f.label :supported_locales, Spree.t(:supported_locales) %>
       <%= f.select :supported_locales, options_from_collection_for_select(all_locales_options, :last, :first, @store.supported_locales&.split(',')), {}, { multiple: true, class: 'select2' } %>
       <%= f.error_message_on :supported_locales %>
     <% end %>
-    <%= f.field_container :default_country_id, class: ['form-group'] do %>
+    <%= f.field_container :default_country_id do %>
       <%= f.label :default_country_id, Spree.t('i18n.default_country') %>
       <%= f.select :default_country_id, options_from_collection_for_select(@countries, :id, :name, @store.default_country_id), {}, { class: 'select2' } %>
       <%= f.error_message_on :default_country_id %>
@@ -196,7 +196,7 @@
       <%= Spree.t('store_form.social_help') %>
     </div>
 
-    <%= f.field_container :facebook, class: ['form-group'] do %>
+    <%= f.field_container :facebook do %>
       <%= f.label :facebook, Spree.t(:facebook) %>
       <div class="input-group mb-3">
         <div class="input-group-prepend">
@@ -206,7 +206,7 @@
       </div>
       <%= f.error_message_on :facebook %>
     <% end %>
-    <%= f.field_container :twitter, class: ['form-group'] do %>
+    <%= f.field_container :twitter do %>
       <%= f.label :twitter, Spree.t(:twitter) %>
       <div class="input-group mb-3">
         <div class="input-group-prepend">
@@ -216,7 +216,7 @@
       </div>
       <%= f.error_message_on :twitter %>
     <% end %>
-    <%= f.field_container :instagram, class: ['form-group'] do %>
+    <%= f.field_container :instagram do %>
       <%= f.label :instagram, Spree.t(:instagram) %>
       <div class="input-group mb-3">
         <div class="input-group-prepend">
@@ -240,17 +240,17 @@
       <%= Spree.t('store_form.footer_help') %>
     </div>
 
-    <%= f.field_container :description, class: ['form-group'] do %>
+    <%= f.field_container :description do %>
       <%= f.label :description, Spree.t(:description) %>
       <%= f.text_area :description, class: 'form-control' %>
       <%= f.error_message_on :description %>
     <% end %>
-    <%= f.field_container :address, class: ['form-group'] do %>
+    <%= f.field_container :address do %>
       <%= f.label :address, Spree.t(:address) %>
       <%= f.text_area :address, class: 'form-control' %>
       <%= f.error_message_on :address %>
     <% end %>
-    <%= f.field_container :contact_phone, class: ['form-group'] do %>
+    <%= f.field_container :contact_phone do %>
       <%= f.label :contact_phone, Spree.t(:contact_phone) %>
       <%= f.text_field :contact_phone, class: 'form-control' %>
       <%= f.error_message_on :contact_phone %>

--- a/app/views/spree/admin/tax_categories/_form.html.erb
+++ b/app/views/spree/admin/tax_categories/_form.html.erb
@@ -1,21 +1,21 @@
 <div data-hook="admin_tax_category_form_fields">
-  <%= f.field_container :name, class: ['form-group'] do %>
+  <%= f.field_container :name do %>
     <%= f.label :name, Spree.t(:name) %>
     <%= f.text_field :name, class: 'form-control' %>
     <%= f.error_message_on :name %>
   <% end %>
 
-  <%= f.field_container :tax_code, class: ['form-group'] do %>
+  <%= f.field_container :tax_code do %>
     <%= f.label :tax_code, Spree.t(:tax_code) %>
     <%= f.text_field :tax_code, class: 'form-control' %>
   <% end %>
 
-  <%= f.field_container :description, class: ['form-group'] do %>
+  <%= f.field_container :description do %>
     <%= f.label :description, Spree.t(:description) %><br>
     <%= f.text_field :description, class: 'form-control' %>
   <% end %>
 
-  <%= f.field_container :is_default, class: ['form-group checkbox'] do %>
+  <%= f.field_container :is_default, class: ['checkbox'] do %>
     <%= f.label :is_default do %>
       <%= f.check_box :is_default %>
       <%= Spree.t(:default) %>

--- a/app/views/spree/admin/tax_rates/_form.html.erb
+++ b/app/views/spree/admin/tax_rates/_form.html.erb
@@ -14,7 +14,7 @@
           <%= f.text_field :name, class: 'form-control' %>
         </div>
         <div data-hook="rate" class="form-group">
-          <%= f.field_container :amount, class: ["form-group"] do %>
+          <%= f.field_container :amount do %>
             <%= f.label :amount, Spree.t(:rate) %>
             <%= f.text_field :amount, class: 'form-control' %>
             <%= f.error_message_on :amount %>

--- a/app/views/spree/admin/taxonomies/_form.html.erb
+++ b/app/views/spree/admin/taxonomies/_form.html.erb
@@ -1,5 +1,5 @@
 <div data-hook="admin_inside_taxonomy_form" class="form-group">
-  <%= f.field_container :name, class: ['form-group'] do %>
+  <%= f.field_container :name do %>
     <%= f.label :name, Spree.t(:name) %> <span class="required">*</span>
     <%= f.text_field :name, class: 'form-control' %>
     <%= f.error_message_on :name, class: 'error-message' %>

--- a/app/views/spree/admin/taxons/_form.html.erb
+++ b/app/views/spree/admin/taxons/_form.html.erb
@@ -1,11 +1,11 @@
 <div data-hook="admin_inside_taxon_form">
-  <%= f.field_container :name, class: ['form-group'] do %>
+  <%= f.field_container :name do %>
     <%= f.label :name, raw(Spree.t(:name) + required_span_tag) %>
     <%= text_field :taxon, :name, class: 'form-control' %>
     <%= f.error_message_on :name, class: 'error-message' %>
   <% end %>
 
-  <%= f.field_container :permalink, class: ['form-group'] do %>
+  <%= f.field_container :permalink do %>
     <%= label_tag :permalink_part, raw(Spree.t(:permalink) + required_span_tag) %>
     <div class="input-group mb-3">
       <div class="input-group-prepend">
@@ -17,7 +17,7 @@
     </div>
   <% end %>
 
-  <%= f.field_container :hide_from_nav, class: ['form-group'] do %>
+  <%= f.field_container :hide_from_nav do %>
     <%= f.label :hide_from_nav do %>
       <%= Spree.t(:hide_from_subcategories_nav) %>
       <br>
@@ -26,7 +26,7 @@
     <% end %>
   <% end %>
 
-  <%= f.field_container :icon, class: ['form-group'] do %>
+  <%= f.field_container :icon do %>
     <%= f.label :icon, Spree.t(:header_banner) %>
     <%= image_tag(main_app.url_for(@taxon.icon.try(:attachment)), class: 'w-100') if @taxon.icon %>
     <%= f.file_field :icon %>
@@ -37,22 +37,22 @@
     <% end %>
   <% end %>
 
-  <%= f.field_container :description, class: ['form-group'] do %>
+  <%= f.field_container :description do %>
     <%= f.label :description, Spree.t(:description) %>
     <%= f.text_area :description, class: "form-control #{'spree-rte' if taxon_wysiwyg_editor_enabled? }", rows: 20 %>
   <% end %>
 
-  <%= f.field_container :meta_title, class: ['form-group'] do %>
+  <%= f.field_container :meta_title do %>
     <%= f.label :meta_title, Spree.t(:meta_title) %>
     <%= f.text_field :meta_title, class: 'form-control', rows: 6 %>
   <% end %>
 
-  <%= f.field_container :meta_description, class: ['form-group'] do %>
+  <%= f.field_container :meta_description do %>
     <%= f.label :meta_description, Spree.t(:meta_description) %>
     <%= f.text_area :meta_description, class: 'form-control', rows: 6 %>
   <% end %>
 
-  <%= f.field_container :meta_keywords, class: ['form-group'] do %>
+  <%= f.field_container :meta_keywords do %>
     <%= f.label :meta_keywords, Spree.t(:meta_keywords) %>
     <%= f.text_field :meta_keywords, class: 'form-control', rows: 6 %>
   <% end %>

--- a/app/views/spree/admin/users/_form.html.erb
+++ b/app/views/spree/admin/users/_form.html.erb
@@ -1,6 +1,6 @@
 <div data-hook="admin_user_form_fields" class="row">
   <div class="col-12 col-md-6">
-    <%= f.field_container :email, class: ['form-group'] do %>
+    <%= f.field_container :email do %>
       <%= f.label :email, Spree.t(:email) %>
       <%= f.email_field :email, class: 'form-control' %>
       <%= f.error_message_on :email %>
@@ -20,13 +20,13 @@
   </div>
 
   <div data-hook="admin_user_form_password_fields" class="col-12 col-md-6">
-    <%= f.field_container :password, class: ['form-group'] do %>
+    <%= f.field_container :password do %>
       <%= f.label :password, Spree.t(:password) %>
       <%= f.password_field :password, class: 'form-control' %>
       <%= f.error_message_on :password %>
     <% end %>
 
-    <%= f.field_container :password_confirmation, class: ['form-group'] do %>
+    <%= f.field_container :password_confirmation do %>
       <%= f.label :password_confirmation, Spree.t(:confirm_password) %>
       <%= f.password_field :password_confirmation, class: 'form-control' %>
       <%= f.error_message_on :password_confirmation %>

--- a/app/views/spree/admin/zones/_country_members.html.erb
+++ b/app/views/spree/admin/zones/_country_members.html.erb
@@ -7,7 +7,7 @@
     </div>
 
     <div class="card-body">
-      <%= zone_form.field_container :country_ids, class: ['form-group'] do %>
+      <%= zone_form.field_container :country_ids do %>
         <%= zone_form.label :country_ids, Spree.t(:countries) %>
         <%= zone_form.collection_select :country_ids, @countries, :id, :name, {}, { multiple: true, class: "select2" } %>
       <% end %>

--- a/app/views/spree/admin/zones/_form.html.erb
+++ b/app/views/spree/admin/zones/_form.html.erb
@@ -6,13 +6,13 @@
       </div>
 
       <div class="card-body">
-        <%= zone_form.field_container :name, class: ['form-group'] do %>
+        <%= zone_form.field_container :name do %>
           <%= zone_form.label :name, Spree.t(:name) %>
           <%= zone_form.text_field :name, class: 'form-control' %>
           <%= zone_form.error_message_on :name %>
         <% end %>
 
-        <%= zone_form.field_container :description, class: ['form-group'] do %>
+        <%= zone_form.field_container :description do %>
           <%= zone_form.label :description, Spree.t(:description) %>
           <%= zone_form.text_field :description, class: 'form-control' %>
         <% end %>

--- a/app/views/spree/admin/zones/_state_members.html.erb
+++ b/app/views/spree/admin/zones/_state_members.html.erb
@@ -7,7 +7,7 @@
     </div>
 
     <div class="card-body">
-      <%= zone_form.field_container :state_ids, class: ['form-group'] do %>
+      <%= zone_form.field_container :state_ids do %>
         <%= zone_form.label :state_ids, Spree.t(:states) %>
         <%= zone_form.collection_select :state_ids, @states, :id, :name, {}, { multiple: true, class: "select2" } %>
       <% end %>

--- a/spec/features/admin/reimbursement_type/edit_reimbursement_type_spec.rb
+++ b/spec/features/admin/reimbursement_type/edit_reimbursement_type_spec.rb
@@ -31,6 +31,6 @@ describe 'edit reimbursement type', type: :feature do
   end
 
   it 'view should have select field' do
-    expect(page).not_to have_css('div#reimbursement_type_type_field.form-group.field')
+    expect(page).not_to have_css('div#reimbursement_type_type_field.form-group')
   end
 end

--- a/spec/features/admin/reimbursement_type/new_reimbursement_type_spec.rb
+++ b/spec/features/admin/reimbursement_type/new_reimbursement_type_spec.rb
@@ -8,7 +8,7 @@ describe 'new reimbursement type', type: :feature do
   end
 
   it 'view should have select field' do
-    expect(page).to have_css('div#reimbursement_type_type_field.form-group.field')
+    expect(page).to have_css('div#reimbursement_type_type_field.form-group')
   end
 
   context 'with valid attributes' do


### PR DESCRIPTION
Move 'form-group' up to the field_container method for easier upgrading to later versions of Bootstrap.

If this is merged this will be part one, part two will be to replace the hard coded `<div class="form-group">` with the field_container method.