### PR TITLE
Remove un-used locals variable

### DIFF
--- a/app/views/spree/admin/products/index.html.erb
+++ b/app/views/spree/admin/products/index.html.erb
@@ -10,7 +10,6 @@
   <div data-hook="admin_products_sidebar">
 
     <%= search_form_for [:admin, @search] do |f| %>
-      <%- locals = {f: f} %>
       <div data-hook="admin_products_index_search" class="row">
         <div class="col-12 col-lg-6">
           <div class="form-group">


### PR DESCRIPTION
![Screen Shot 2021-12-28 at 4 00 58 PM](https://user-images.githubusercontent.com/23930/147543147-eafb44dd-7731-4695-adc0-1adddcc998da.png)

This locals variable is not used anywhere in the admin/products/index.html.erb template right now since the hooks call no longer exists.