### PR TITLE
VEN-178 Adds Store Search To Spree

### DIFF
--- a/app/assets/stylesheets/spree/backend/components/_buttons.scss
+++ b/app/assets/stylesheets/spree/backend/components/_buttons.scss
@@ -16,7 +16,7 @@
   }
   svg,
   i.icon {
-   margin-bottom: 3px;
+   margin-bottom: 1px;
   }
 }
 

--- a/app/assets/stylesheets/spree/backend/components/_navbar.scss
+++ b/app/assets/stylesheets/spree/backend/components/_navbar.scss
@@ -20,39 +20,33 @@
         line-height: 1rem;
       }
     }
+  }
+}
 
-    #storeSwitcherDropdown {
-      .dropdown-menu.show {
-        min-width: 250px;
-        width: fit-content;
-        max-width: 90vw;
-        max-height: 70vh;
-        overflow-y: scroll !important;
-        top: $navbar-brand-height + 1.5rem;
-        left: 50%;
-        right: 50%;
-        transform: translate(-50%, 0%);
+#storeSwitcherDropdown,
+#storeSwitcherDropdownMobile
+ {
+  .dropdown-menu.show {
+    min-width: 250px;
+    width: fit-content;
+    max-width: 90vw;
+    max-height: 70vh;
+    overflow-y: scroll !important;
+    top: $navbar-brand-height + 1rem;
+    left: 0%;
 
-        @include media-breakpoint-up(lg) {
-          left: 0%;
-          right: 0%;
-          transform: translate(0%, 0%);
-        }
+    a {
+      white-space: nowrap;
+      overflow-x: hidden;
+      text-overflow: ellipsis;
 
-        a {
-          white-space: nowrap;
-          overflow-x: hidden;
-          text-overflow: ellipsis;
+      svg {
+        vertical-align: text-top;
+        margin-right: 1em;
+      }
 
-          svg {
-            vertical-align: text-top;
-            margin-right: 1em;
-          }
-
-          &.disabled svg {
-            color: theme-color('success');
-          }
-        }
+      &.disabled svg {
+        color: theme-color('success');
       }
     }
   }

--- a/app/assets/stylesheets/spree/backend/plugins/_autocomplete.scss
+++ b/app/assets/stylesheets/spree/backend/plugins/_autocomplete.scss
@@ -1,0 +1,62 @@
+.autoComplete_wrapper {
+  display: block;
+  position: relative;
+  margin: auto;
+  max-width: 800px;
+}
+
+.autoComplete_wrapper > input {
+  text-overflow: ellipsis;
+}
+
+.autoComplete_wrapper > input:hover {
+  transition: all 0.3s ease;
+  -webkit-transition: all -webkit-transform 0.3s ease;
+}
+
+.autoComplete_wrapper > ul {
+  position: absolute;
+  max-height: 226px;
+  overflow-y: scroll;
+  box-sizing: border-box;
+  left: 0;
+  right: 0;
+  margin: 0.5rem 0 0 0;
+  padding: 0;
+  z-index: 1;
+  list-style: none;
+  border-radius: 0.6rem;
+  background-color: #fff;
+  border: 1px solid rgba(33, 33, 33, 0.07);
+  box-shadow: 0 3px 6px rgba(149, 157, 165, 0.15);
+  outline: none;
+  transition: opacity 0.15s ease-in-out;
+  -moz-transition: opacity 0.15s ease-in-out;
+  -webkit-transition: opacity 0.15s ease-in-out;
+}
+
+.autoComplete_wrapper > ul[hidden],
+.autoComplete_wrapper > ul:empty {
+  display: block;
+  opacity: 0;
+  transform: scale(0);
+}
+
+.autoComplete_wrapper > ul > li {
+  margin: 0.3rem;
+  padding: 0.3rem 0.5rem;
+  text-align: left;
+  font-size: 1rem;
+  color: #212121;
+  border-radius: 0.35rem;
+  background-color: rgba(255, 255, 255, 1);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: all 0.2s ease;
+}
+
+.autoComplete_wrapper > ul > li:hover {
+  cursor: pointer;
+  background-color: $gray-200;
+}

--- a/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -49,3 +49,10 @@ input[type="file"] {
   background: $input-bg url(asset-path("backend-chevron-down.svg")) no-repeat right 0.5rem center/8px 10px;
   background-size: 0.7em;
 }
+
+span.global-search-result-sub {
+  font-size: 13px;
+  font-weight: 100;
+  text-transform: uppercase;
+  color: rgba(0,0,0,.8);
+}

--- a/app/assets/stylesheets/spree/backend/spree_admin.css.scss
+++ b/app/assets/stylesheets/spree/backend/spree_admin.css.scss
@@ -18,6 +18,7 @@
 @import 'spree/backend/components/taxon_products_view';
 
 @import 'spree/backend/plugins/sweetalert2_custom';
+@import 'spree/backend/plugins/autocomplete';
 @import 'spree/backend/plugins/jquery_ui';
 @import 'spree/backend/plugins/flatpickr';
 @import 'spree/backend/plugins/select2_bootstrap4';

--- a/app/javascript/spree/dashboard/controllers/search_controller.js
+++ b/app/javascript/spree/dashboard/controllers/search_controller.js
@@ -107,7 +107,7 @@ export default class extends Controller {
       taxons.data.forEach(function (taxon) {
         response_array.push({
           "taxon": taxon.attributes.name,
-          "uri": `${Spree.adminPath}taxonomies/${taxon.relationships.taxonomy.data.id}/taxons/${taxon.id}/edit`,
+          "uri": `/${Spree.adminPath()}taxonomies/${taxon.relationships.taxonomy.data.id}/taxons/${taxon.id}/edit`,
           "pretty_name": taxon.attributes.pretty_name,
           "permalink": taxon.attributes.permalink,
 

--- a/app/javascript/spree/dashboard/controllers/search_controller.js
+++ b/app/javascript/spree/dashboard/controllers/search_controller.js
@@ -1,0 +1,171 @@
+import { Controller } from "@hotwired/stimulus"
+import autoComplete from "@tarekraafat/autocomplete.js"
+import { get } from "../utilities/request_utility"
+
+export default class extends Controller {
+  connect() {
+    const autoCompleteJS = new autoComplete(
+      {
+        placeHolder: "Search",
+        data: {
+          src: async (query) => {
+            try {
+              // Taxons
+              const taxons = await get(`/api/v2/platform/taxons?filter[name_cont]=${query}`)
+              const taxons_response = await taxons.json
+
+              // Products
+              const variants = await get(`/api/v2/platform/variants?filter[product_name_or_sku_cont]=${query}`)
+              const variants_response = await variants.json
+
+              // Users
+              const users = await get(`/api/v2/platform/users?filter[email_cont]=${query}`)
+              const users_response = await users.json
+
+              // Orders
+              const orders = await get(`/api/v2/platform/orders?filter[number_or_email_cont]=${query}`)
+              const orders_response = await orders.json
+
+              // Pages
+              const pages = await get(`/api/v2/platform/cms_pages?filter[title_cont]=${query}`)
+              const pages_response = await pages.json
+
+              return formatResponse(taxons_response, variants_response, users_response, orders_response, pages_response)
+
+            } catch (error) {
+              return error
+            }
+          },
+
+          // Data 'Object' key to be searched
+          keys: ["taxon", "product", "user", "order", "page"]
+        },
+        threshold: 3,
+        resultsList: {
+          maxResults: 50,
+        },
+        resultItem: {
+          element: (item, data) => {
+            // Modify Results Item Style
+            item.style = "display: flex; justify-content: space-between;"
+            // Modify Results Item Content
+
+            if (data.key === "product") {
+              item.innerHTML = `
+                <span style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
+                  ${data.value.name}
+                  <br>
+                  <span class="global-search-result-sub">sku: </span> ${data.value.sku}
+                </span>
+                <span style="display: flex; align-items: center; font-size: 13px; font-weight: 100; text-transform: uppercase; color: rgba(0,0,0,.8);">
+                  ${data.key}
+                </span>`
+            } else if (data.key === "order") {
+              item.innerHTML = `
+                <span style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
+                  ${data.value.number}
+                  <br>
+                  <span class="global-search-result-sub">email: </span> ${data.value.email}
+                  <br>
+                  <span class="global-search-result-sub">state: </span> ${data.value.state}
+                </span>
+                <span style="display: flex; align-items: center; font-size: 13px; font-weight: 100; text-transform: uppercase; color: rgba(0,0,0,.8);">
+                  ${data.key}
+                </span>`
+            } else if (data.key === "taxon") {
+              item.innerHTML = `
+                <span style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
+                  ${data.value.pretty_name}
+                  <br>
+                  <span class="global-search-result-sub">permalink: </span> ${data.value.permalink}
+                </span>
+                <span style="display: flex; align-items: center; font-size: 13px; font-weight: 100; text-transform: uppercase; color: rgba(0,0,0,.8);">
+                  ${data.key}
+                </span>`
+            } else {
+              item.innerHTML = `
+                <span style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
+                  ${data.match}
+                </span>
+                <span style="display: flex; align-items: center; font-size: 13px; font-weight: 100; text-transform: uppercase; color: rgba(0,0,0,.8);">
+                  ${data.key}
+                </span>`
+            }
+          },
+
+          highlight: false
+        }
+      })
+
+    function formatResponse(taxons, variants, users, orders, pages) {
+      let response_array = []
+
+      taxons.data.forEach(function (taxon) {
+        response_array.push({
+          "taxon": taxon.attributes.name,
+          "uri": `/admin/taxonomies/${taxon.relationships.taxonomy.data.id}/taxons/${taxon.id}/edit`,
+          "pretty_name": taxon.attributes.pretty_name,
+          "permalink": taxon.attributes.permalink,
+
+          // Placeholders
+          "product": "", "user": "", "order": "", "page": ""
+        })
+      })
+
+      variants.data.forEach(function (variant) {
+        response_array.push({
+          "product": variant.attributes.name + " " + variant.attributes.sku,
+          "uri": `/admin/products/${variant.relationships.product.data.id}/edit`,
+          "sku": variant.attributes.sku,
+          "name": variant.attributes.name,
+
+          // Placeholders
+          "user": "", "order": "", "taxon": "", "page": ""
+        })
+      })
+
+      users.data.forEach(function (user) {
+        response_array.push({
+          "user": user.attributes.email,
+          "uri": `/admin/users/${user.id}/edit`,
+
+          // Placeholders
+          "product": "", "order": "", "taxon": "", "page": ""
+        })
+      })
+
+      orders.data.forEach(function (order) {
+        console.log(order)
+        response_array.push({
+          "order": order.attributes.number + " " + order.attributes.email,
+          "uri": `/admin/orders/${order.attributes.number}/edit`,
+          "email": order.attributes.email,
+          "number": order.attributes.number,
+          "state": order.attributes.state,
+
+          // Placeholders
+          "product": "", "user": "", "taxon": "", "page": ""
+        })
+      })
+
+      pages.data.forEach(function (page) {
+        response_array.push({
+          "page": page.attributes.title,
+          "uri": `/admin/cms_pages/${page.id}/edit`,
+
+          // Placeholders
+          "order": "", "product": "", "user": "", "taxon": ""
+        })
+      })
+
+      return response_array
+    }
+
+    // Redirect to URI on selection
+    autoCompleteJS.input.addEventListener("selection", function (event) {
+      const uri = event.detail.selection.value["uri"]
+
+      Turbo.visit(uri)
+    })
+  }
+}

--- a/app/javascript/spree/dashboard/controllers/search_controller.js
+++ b/app/javascript/spree/dashboard/controllers/search_controller.js
@@ -1,33 +1,37 @@
+/* eslint-disable no-undef */
+
 import { Controller } from "@hotwired/stimulus"
 import autoComplete from "@tarekraafat/autocomplete.js"
 import { get } from "../utilities/request_utility"
 
 export default class extends Controller {
   connect() {
-    const autoCompleteJS = new autoComplete(
+    const storeSearch = new autoComplete(
       {
-        placeHolder: "Search",
+        placeHolder: Spree.translations.search,
+        selector: "#storeSearch",
         data: {
           src: async (query) => {
             try {
+
               // Taxons
-              const taxons = await get(`/api/v2/platform/taxons?filter[name_cont]=${query}`)
+              const taxons = await get(`${Spree.routes.taxons_api_v2}?filter[name_cont]=${query}`)
               const taxons_response = await taxons.json
 
               // Products
-              const variants = await get(`/api/v2/platform/variants?filter[product_name_or_sku_cont]=${query}`)
+              const variants = await get(`${Spree.routes.variants_api_v2}?filter[product_name_or_sku_cont]=${query}`)
               const variants_response = await variants.json
 
               // Users
-              const users = await get(`/api/v2/platform/users?filter[email_cont]=${query}`)
+              const users = await get(`${Spree.routes.users_api_v2}?filter[email_cont]=${query}`)
               const users_response = await users.json
 
               // Orders
-              const orders = await get(`/api/v2/platform/orders?filter[number_or_email_cont]=${query}`)
+              const orders = await get(`${Spree.routes.orders_api_v2}?filter[number_or_email_cont]=${query}`)
               const orders_response = await orders.json
 
               // Pages
-              const pages = await get(`/api/v2/platform/cms_pages?filter[title_cont]=${query}`)
+              const pages = await get(`${Spree.routes.pages_api_v2}?filter[title_cont]=${query}`)
               const pages_response = await pages.json
 
               return formatResponse(taxons_response, variants_response, users_response, orders_response, pages_response)
@@ -103,7 +107,7 @@ export default class extends Controller {
       taxons.data.forEach(function (taxon) {
         response_array.push({
           "taxon": taxon.attributes.name,
-          "uri": `/admin/taxonomies/${taxon.relationships.taxonomy.data.id}/taxons/${taxon.id}/edit`,
+          "uri": `${Spree.adminPath}taxonomies/${taxon.relationships.taxonomy.data.id}/taxons/${taxon.id}/edit`,
           "pretty_name": taxon.attributes.pretty_name,
           "permalink": taxon.attributes.permalink,
 
@@ -115,7 +119,7 @@ export default class extends Controller {
       variants.data.forEach(function (variant) {
         response_array.push({
           "product": variant.attributes.name + " " + variant.attributes.sku,
-          "uri": `/admin/products/${variant.relationships.product.data.id}/edit`,
+          "uri": `/${Spree.adminPath()}products/${variant.relationships.product.data.id}/edit`,
           "sku": variant.attributes.sku,
           "name": variant.attributes.name,
 
@@ -127,7 +131,7 @@ export default class extends Controller {
       users.data.forEach(function (user) {
         response_array.push({
           "user": user.attributes.email,
-          "uri": `/admin/users/${user.id}/edit`,
+          "uri": `/${Spree.adminPath()}users/${user.id}/edit`,
 
           // Placeholders
           "product": "", "order": "", "taxon": "", "page": ""
@@ -138,7 +142,7 @@ export default class extends Controller {
         console.log(order)
         response_array.push({
           "order": order.attributes.number + " " + order.attributes.email,
-          "uri": `/admin/orders/${order.attributes.number}/edit`,
+          "uri": `/${Spree.adminPath()}orders/${order.attributes.number}/edit`,
           "email": order.attributes.email,
           "number": order.attributes.number,
           "state": order.attributes.state,
@@ -151,7 +155,7 @@ export default class extends Controller {
       pages.data.forEach(function (page) {
         response_array.push({
           "page": page.attributes.title,
-          "uri": `/admin/cms_pages/${page.id}/edit`,
+          "uri": `/${Spree.adminPath()}cms_pages/${page.id}/edit`,
 
           // Placeholders
           "order": "", "product": "", "user": "", "taxon": ""
@@ -162,8 +166,8 @@ export default class extends Controller {
     }
 
     // Redirect to URI on selection
-    autoCompleteJS.input.addEventListener("selection", function (event) {
-      const uri = event.detail.selection.value["uri"]
+    storeSearch.input.addEventListener("selection", function (event) {
+      const uri = event.detail.selection.value.uri
 
       Turbo.visit(uri)
     })

--- a/app/javascript/spree/dashboard/index.js
+++ b/app/javascript/spree/dashboard/index.js
@@ -44,6 +44,9 @@ application.register("password-toggle", PasswordToggleController)
 import ClipboardController from "./controllers/clipboard_controller"
 application.register("clipboard", ClipboardController)
 
+import SearchController from "./controllers/search_controller"
+application.register("search", SearchController)
+
 //
 // Export
 export { Dashboard, application, flatpickr, Turbo }

--- a/app/views/spree/admin/shared/_account_nav.html.erb
+++ b/app/views/spree/admin/shared/_account_nav.html.erb
@@ -1,59 +1,55 @@
 <% if try_spree_current_user %>
-  <div class="btn-group">
+  <button id="accountNav" type="button" class="btn  btn-primary mr-2" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  <%= svg_icon name: "user.svg", width: '24', height: '24', classes: 'mb-0' %>
+  </button>
 
-    <button id="accountNav" type="button" class="btn text-light px-3" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-      <%= svg_icon name: "user.svg", width: '24', height: '24', classes: 'mb-0' %>
-    </button>
-
-    <div class="dropdown-menu dropdown-menu-right overflow-hidden mt-2 p-0 mr-2">
-      <div class="dropdown-item px-0 text-center bg-light">
-        <span class="d-block py-2 px-4"><%= try_spree_current_user.email %></span>
-      </div>
-      <div class="dropdown-divider m-0"></div>
-
-      <% if spree.respond_to? :root_path %>
-          <%= link_to spree.root_path, target: :blank, class: 'd-block py-2 px-4 my-1 dropdown-item', data: { turbo: false } do %>
-            <%= svg_icon name: "store.svg", width: '18', height: '18' %>
-            &nbsp;
-            <%= Spree.t(:back_to_store) %>
-          <% end %>
-      <% end %>
-
-      <% if can?(:manage, try_spree_current_user) %>
-          <%= link_to spree.edit_admin_user_path(try_spree_current_user), class: 'd-block py-2 px-4 my-1 dropdown-item' do %>
-            <%= svg_icon name: "user.svg", width: '18', height: '18' %>
-            &nbsp;
-            <%= Spree.t(:account) %>
-          <% end %>
-      <% end %>
-
-      <% if admin_logout_link %>
-          <%= link_to admin_logout_link, class: 'd-block py-2 px-4 my-1 dropdown-item' do %>
-            <%= svg_icon name: "exit.svg", width: '18', height: '18' %>
-            &nbsp;
-            <%= Spree.t(:logout) %>
-          <% end %>
-      <% end %>
-
-      <div class="dropdown-divider m-0"></div>
-
-        <%= link_to 'http://spreecommerce.org/contact', target: :blank, class: 'd-block py-2 px-4 my-1 dropdown-item' do %>
-        <%= svg_icon name: "info.svg", width: '18', height: '18' %>
-          &nbsp;
-          <%= Spree.t(:support) %>
-        <% end %>
-
-        <%= link_to 'http://slack.spreecommerce.org', target: :blank, class: 'd-block py-2 px-4 my-1 dropdown-item' do %>
-        <%= svg_icon name: "slack.svg", width: '18', height: '18' %>
-          &nbsp;
-          <%= Spree.t(:join_slack) %>
-        <% end %>
-
-        <%= link_to 'https://dev-docs.spreecommerce.org/extensions/extensions', target: :blank, class: 'd-block py-2 px-4 my-1 dropdown-item' do %>
-        <%= svg_icon name: "extensions.svg", width: '18', height: '18' %>
-          &nbsp;
-          <%= Spree.t(:extensions_directory) %>
-        <% end %>
+  <div class="dropdown-menu dropdown-menu-right overflow-hidden mt-2 p-0 mr-2">
+    <div class="dropdown-item px-0 text-center bg-light">
+      <span class="d-block py-2 px-4"><%= try_spree_current_user.email %></span>
     </div>
+
+    <div class="dropdown-divider m-0"></div>
+    <% if spree.respond_to? :root_path %>
+        <%= link_to spree.root_path, target: :blank, class: 'd-block py-2 px-4 my-1 dropdown-item', data: { turbo: false } do %>
+          <%= svg_icon name: "store.svg", width: '18', height: '18' %>
+          &nbsp;
+          <%= Spree.t(:back_to_store) %>
+        <% end %>
+    <% end %>
+
+    <% if can?(:manage, try_spree_current_user) %>
+        <%= link_to spree.edit_admin_user_path(try_spree_current_user), class: 'd-block py-2 px-4 my-1 dropdown-item' do %>
+          <%= svg_icon name: "user.svg", width: '18', height: '18' %>
+          &nbsp;
+          <%= Spree.t(:account) %>
+        <% end %>
+    <% end %>
+
+    <% if admin_logout_link %>
+        <%= link_to admin_logout_link, class: 'd-block py-2 px-4 my-1 dropdown-item' do %>
+          <%= svg_icon name: "exit.svg", width: '18', height: '18' %>
+          &nbsp;
+          <%= Spree.t(:logout) %>
+        <% end %>
+    <% end %>
+
+    <div class="dropdown-divider m-0"></div>
+      <%= link_to 'https://spreecommerce.org/contact', target: :blank, class: 'd-block py-2 px-4 my-1 dropdown-item' do %>
+      <%= svg_icon name: "info.svg", width: '18', height: '18' %>
+        &nbsp;
+        <%= Spree.t(:support) %>
+      <% end %>
+
+      <%= link_to 'https://slack.spreecommerce.org', target: :blank, class: 'd-block py-2 px-4 my-1 dropdown-item' do %>
+      <%= svg_icon name: "slack.svg", width: '18', height: '18' %>
+        &nbsp;
+        <%= Spree.t(:join_slack) %>
+      <% end %>
+
+      <%= link_to 'https://dev-docs.spreecommerce.org/extensions/extensions', target: :blank, class: 'd-block py-2 px-4 my-1 dropdown-item' do %>
+      <%= svg_icon name: "extensions.svg", width: '18', height: '18' %>
+        &nbsp;
+        <%= Spree.t(:extensions_directory) %>
+      <% end %>
   </div>
 <% end %>

--- a/app/views/spree/admin/shared/_header.html.erb
+++ b/app/views/spree/admin/shared/_header.html.erb
@@ -11,13 +11,15 @@
       </button>
     </div>
 
-    <div id="storeSwitcherDropdown" class="d-none d-md-flex col-auto text-center text-lg-left text-light px-0 px-lg-2 align-items-center dropdown">
+    <div id="storeSwitcherDropdown" class="d-none d-md-flex col-auto text-center text-lg-left text-light align-items-center dropdown">
       <%= render partial: 'spree/admin/shared/store_switcher' %>
     </div>
 
-    <div data-controller="search" class="m-2 w-100">
-      <input id="autoComplete" class="form-control">
-    </div>
+    <% if can?(:admin, current_store) %>
+      <div data-controller="search" class="m-2 w-100">
+        <input id="storeSearch" class="form-control">
+      </div>
+    <% end %>
 
     <div class="col text-right p-0">
       <%= render partial: 'spree/admin/shared/account_nav' %>

--- a/app/views/spree/admin/shared/_header.html.erb
+++ b/app/views/spree/admin/shared/_header.html.erb
@@ -3,7 +3,7 @@
     <div class="col p-0 d-lg-none">
       <button
         id="sidebar-open"
-        class="navbar-toggler h-100 text-light px-3"
+        class="btn btn-primary m-2"
         type="button"
         aria-expanded="false"
         aria-label="Toggle navigation">
@@ -11,8 +11,12 @@
       </button>
     </div>
 
-    <div id="storeSwitcherDropdown" class="col-auto text-center text-lg-left px-0 px-lg-2 align-items-center dropdown">
+    <div id="storeSwitcherDropdown" class="d-none d-md-flex col-auto text-center text-lg-left text-light px-0 px-lg-2 align-items-center dropdown">
       <%= render partial: 'spree/admin/shared/store_switcher' %>
+    </div>
+
+    <div data-controller="search" class="m-2 w-100">
+      <input id="autoComplete" class="form-control">
     </div>
 
     <div class="col text-right p-0">

--- a/app/views/spree/admin/shared/_main_menu.html.erb
+++ b/app/views/spree/admin/shared/_main_menu.html.erb
@@ -1,14 +1,21 @@
 <nav>
   <div class="text-right d-lg-none pl-3 py-2 border-bottom d-flex align-items-center">
-    <div class="d-flex flex-grow-1 text-primary">
-      <%= svg_icon name: "spree-logo.svg", width: '70', height: '30' %>
+    <div class="d-flex flex-grow-1">
+      <div class="d-none d-md-flex flex-grow-1 text-primary">
+        <%= svg_icon name: "spree-logo.svg", width: '70', height: '30'%>
+      </div>
+
+      <div id="storeSwitcherDropdownMobile" class="d-flex d-md-none col-auto text-center text-lg-left px-0 px-lg-2 align-items-center dropdown">
+        <%= render partial: 'spree/admin/shared/store_switcher' %>
+      </div>
     </div>
+
     <button
       id="sidebar-close"
       class="btn btn-link d-flex"
       type="button"
       aria-expanded="false"
-      aria-label="Toggle navigation">
+      aria-label="Toggle Navigation">
       <%= svg_icon name: "cancel.svg", width: '20', height: '20', classes: 'p-0 m-0' %>
     </button>
   </div>

--- a/app/views/spree/admin/shared/_store_switcher.html.erb
+++ b/app/views/spree/admin/shared/_store_switcher.html.erb
@@ -1,23 +1,22 @@
 <% if can?(:admin, current_store) %>
-    <span class="d-none d-lg-inline text-light">
-      <%= svg_icon name: "spree-icon.svg", width: '35', height: '35' %>
-    </span>
+  <span class="d-none d-lg-inline mr-2">
+    <%= svg_icon name: "spree-icon.svg", width: '35', height: '35' %>
+  </span>
 
-    <a class="px-0 py-1 btn text-light" id="storeSelectorDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-     <span class="d-sm-none"><%= svg_icon name: "store.svg", width: '18', height: '18' %></span>
-     <span class="d-none d-sm-inline"><%= current_store.name %></span> (<%= current_store.code %>) <%= svg_icon name: "chevron-down.svg", width: '12', height: '12', classes: 'ml-1 mb-0' %>
-    </a>
+  <a class="btn btn-primary" id="storeSelectorDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+   <%= current_store.name %> (<%= current_store.code %>) <%= svg_icon name: "chevron-down.svg", width: '12', height: '12', classes: 'ml-1 mb-0' %>
+  </a>
 
-    <div class="dropdown-menu dropdown-menu-left overflow-hidden ml-2" aria-labelledby="storeSelectorDropdown">
-      <% @stores.each do |store| %>
-        <%= store_switcher_link(store) %>
+  <div class="dropdown-menu dropdown-menu-left overflow-hidden mx-2" aria-labelledby="storeSelectorDropdown">
+    <% @stores.each do |store| %>
+      <%= store_switcher_link(store) %>
+    <% end %>
+
+    <% if can?(:create, Spree::Store) %>
+      <div class="dropdown-divider m-0"></div>
+      <%= link_to spree.new_admin_store_path, class: 'py-2 px-4 mt-1 mb-0 dropdown-item', id: 'addNewStoreLink' do %>
+        <%= svg_icon name: "add.svg", width: '18', height: '18' %> <%= Spree.t(:add_new_store) %>
       <% end %>
-
-      <% if can?(:create, Spree::Store) %>
-        <div class="dropdown-divider m-0"></div>
-        <%= link_to spree.new_admin_store_path, class: 'py-2 px-4 mt-1 mb-0 dropdown-item', id: 'addNewStoreLink' do %>
-          <%= svg_icon name: "add.svg", width: '18', height: '18' %> <%= Spree.t(:add_new_store) %>
-        <% end %>
-      <% end %>
-    </div>
+    <% end %>
+  </div>
 <% end %>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "@hotwired/stimulus": "^3.0.1",
     "@hotwired/turbo": "^7.0.1",
-    "@rails/request.js": "^0.0.5",
+    "@rails/request.js": "^0.0.6",
+    "@tarekraafat/autocomplete.js": "^10.2.6",
     "bootstrap": "4.6.1",
     "flatpickr": "^4.6.9",
     "jquery": "3.5.1",

--- a/spec/features/admin/search_spec.rb
+++ b/spec/features/admin/search_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+
+describe 'Store Wide Search', type: :feature, js: true do
+  stub_authorization!
+
+  let!(:store) { Spree::Store.default }
+  let!(:product) { create(:product, name: 'spree t-shirt', price: 20.00, stores: [store]) }
+  let!(:order) { create(:order, state: 'complete', completed_at: '2011-02-01 12:36:15', number: 'R02487872', store: store) }
+  let!(:cms_page) { create(:cms_standard_page, store: store, title: 'About Us') }
+  let!(:taxonomy) { create(:taxonomy, name: 'clothing') }
+  let!(:taxon_a) { create(:taxon, taxonomy: taxonomy, name: 'Trousers') }
+
+  before { visit spree.admin_path }
+
+  context 'searching orders' do
+    it 'finds the order by number and redirects to the order edit page' do
+      fill_in 'storeSearch', with: 'R02487872'
+
+      wait_for_turbo
+      find('#autoComplete_result_0').click
+      wait_for_turbo
+      expect(page).to have_selector('h4', text: 'R02487872')
+    end
+
+    it 'finds the order by email and redirects to the order edit page' do
+      fill_in 'storeSearch', with: order.email
+
+      wait_for_turbo
+      find('#autoComplete_result_1').click
+      wait_for_turbo
+      expect(page).to have_selector('h4', text: 'R02487872')
+    end
+  end
+
+  context 'searching for a user' do
+    it 'finds the user by email and redirects to the user edit page' do
+      fill_in 'storeSearch', with: order.email
+
+      wait_for_turbo
+      find('#autoComplete_result_0').click
+      wait_for_turbo
+      expect(page).to have_selector('h4', text: order.email)
+    end
+  end
+
+  context 'searching for a cms_page' do
+    it 'finds the cms_page by title and redirects to the edit cms_page' do
+      fill_in 'storeSearch', with: 'About'
+
+      wait_for_turbo
+      find('#autoComplete_result_0').click
+      wait_for_turbo
+      expect(page).to have_selector('h4', text: 'All Pages / About Us')
+    end
+  end
+
+  context 'searching for a product' do
+    it 'finds the product by name and redirects to the product edit page' do
+      fill_in 'storeSearch', with: product.name
+
+      wait_for_turbo
+      find('#autoComplete_result_0').click
+      wait_for_turbo
+      expect(page).to have_selector('h4', text: product.name)
+    end
+
+    it 'finds the product by SKU and redirects to the product edit page' do
+      fill_in 'storeSearch', with: product.sku
+
+      wait_for_turbo
+      find('#autoComplete_result_0').click
+      wait_for_turbo
+      expect(page).to have_selector('h4', text: product.name)
+    end
+  end
+
+  context 'searching for a taxon' do
+    it 'finds the taxon by name and redirects to the taxon edit page' do
+      fill_in 'storeSearch', with: 'Trousers'
+
+      wait_for_turbo
+      find('#autoComplete_result_0').click
+      wait_for_turbo
+      expect(page).to have_selector('h4', text: 'Taxonomies / clothing / Trousers')
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,10 +62,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@rails/request.js@^0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@rails/request.js/-/request.js-0.0.5.tgz#5ea896085f1c82bacca0e32aa918c8cd003a3d30"
-  integrity sha512-EDw3d5oCSPFn/os7C41+61urT5J5n+bMXK2NTQVhJI8VCPAIVbvFGjZIQI0a9zJ9KuaWKHM6IjXTRakKemlzoA==
+"@rails/request.js@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@rails/request.js/-/request.js-0.0.6.tgz#5f0347a9f363e50ec45118c7134080490cda81d8"
+  integrity sha512-dfFWaQXitYJ4kxrgGJNhDNXX54/v10YgoJqBMVe6lhqs6a4N9WD7goZJEvwin82TtK8MqUNhwfyisgKwM6dMdg==
 
 "@rollup/plugin-commonjs@^19.0.1":
   version "19.0.2"
@@ -100,6 +100,11 @@
     "@types/estree" "0.0.39"
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
+
+"@tarekraafat/autocomplete.js@^10.2.6":
+  version "10.2.6"
+  resolved "https://registry.yarnpkg.com/@tarekraafat/autocomplete.js/-/autocomplete.js-10.2.6.tgz#c25a35b09cd5af15ee2941950d5ae52a79b77abf"
+  integrity sha512-M3awL75YTQVHev4XlWGRKJalwVG3MGgtNnbRdtNipcyMcAV1sfkireBM8BKL/vhFhrus+6/5KZfj/DJDu8X0mg==
 
 "@types/estree@*":
   version "0.0.50"


### PR DESCRIPTION
Adds a global search bar to Spree Backend allowing admins to search within the current store and find:

- Products by Name or SKU
- Taxon by Name
- Orders by Name or Email
- Pages by Title
- Users by Email

Uses:

- Platform API
- Stimulus
- @rails/Request.js
- autoComplete.js