### PR TITLE
VEN-259 UX: when saving/creating/removing product properties it should redirect back to product properties, not product edit

### DIFF
--- a/app/controllers/spree/admin/products_controller.rb
+++ b/app/controllers/spree/admin/products_controller.rb
@@ -102,7 +102,11 @@ module Spree
       end
 
       def location_after_save
-        spree.edit_admin_product_url(@product)
+        if params[:product][:product_properties_attributes].present?
+          spree.admin_product_product_properties_path(@product)
+        else
+          spree.edit_admin_product_url(@product)
+        end
       end
 
       def load_data

--- a/spec/features/admin/products/edit/properties_spec.rb
+++ b/spec/features/admin/products/edit/properties_spec.rb
@@ -3,8 +3,9 @@ require 'spec_helper'
 describe 'Product Properties', type: :feature, js: true do
   stub_authorization!
 
+  let!(:product) { create(:product, stores: Spree::Store.all) }
+
   before do
-    create(:product, stores: Spree::Store.all)
     visit spree.admin_products_path
   end
 
@@ -17,7 +18,7 @@ describe 'Product Properties', type: :feature, js: true do
       fill_in 'product_product_properties_attributes_0_value', with: 'Leather'
       click_button 'Update'
 
-      within('#tabs') { click_link 'Properties' }
+      expect(page).to have_current_path(spree.admin_product_product_properties_path(product))
       expect(page).to have_content('Add Product Properties')
       expect(page).to have_content('SHOW PROPERTY')
       expect(page).to have_selector("input[value='Material']")
@@ -34,7 +35,7 @@ describe 'Product Properties', type: :feature, js: true do
       find(:css, "#product_product_properties_attributes_0_show_property").set(false)
       click_button 'Update'
 
-      within('#tabs') { click_link 'Properties' }
+      expect(page).to have_current_path(spree.admin_product_product_properties_path(product))
       expect(page).to have_selector("input[value='gtin']")
       expect(page).to have_selector("input[value='9020188287332']")
       expect(page).to have_field('product_product_properties_attributes_0_show_property', checked: false)

--- a/spec/features/admin/products/products_spec.rb
+++ b/spec/features/admin/products/products_spec.rb
@@ -393,6 +393,13 @@ describe 'Products', type: :feature do
         end
       end
 
+      it 'redirects to edit product page' do
+        visit spree.admin_product_path(product)
+        click_button 'Update'
+
+        expect(page).to have_current_path(spree.edit_admin_product_path(product))
+      end
+
       context 'using a locale with a different decimal format' do
         before do
           # change English locale's separator and delimiter to match 19,99 format


### PR DESCRIPTION
https://getvendo.atlassian.net/browse/VEN-259