### PR TITLE
VEN-290 When creating a new store, default country should be always the defaylt country of the default store

### DIFF
--- a/app/controllers/spree/admin/stores_controller.rb
+++ b/app/controllers/spree/admin/stores_controller.rb
@@ -86,7 +86,7 @@ module Spree
       end
 
       def set_default_country_id
-        @store.default_country_id = Spree::Config[:default_country_id]
+        @store.default_country_id ||= Spree::Store.default.default_country_id || Spree::Country.find_by(iso: "US")&.id
       end
     end
   end

--- a/spec/features/admin/configuration/stores_spec.rb
+++ b/spec/features/admin/configuration/stores_spec.rb
@@ -10,10 +10,42 @@ describe 'Stores admin', type: :feature do
   before { store.update!(checkout_zone: zone) }
 
   describe 'creating store' do
-    it 'sets default currency value', js: true do
-      visit spree.new_admin_store_path
-      expect(page).to have_selector(:id, 'select2-store_default_currency-container', text: 'United States Dollar (USD)')
-      expect(page).to have_field('store_checkout_zone_id', text: 'No Limits')
+    context 'setting default values', js: true do
+      it 'sets default currency value' do
+        visit spree.new_admin_store_path
+        expect(page).to have_selector(:id, 'select2-store_default_currency-container', text: 'United States Dollar (USD)')
+      end
+
+      it 'sets default checkout zone' do
+        visit spree.new_admin_store_path
+        expect(page).to have_field('store_checkout_zone_id', text: 'No Limits')
+      end
+
+      context 'default country' do
+        let!(:default_country) { create(:country) }
+
+        context 'when default store has default_country_id' do
+          before do
+            Spree::Store.default.update(default_country_id: default_country.id)
+            visit spree.new_admin_store_path
+          end
+
+          it 'sets default country of new Store to the default store\'s default country' do
+            expect(page).to have_field('store_default_country_id', text: default_country.to_s)
+          end
+        end
+
+        context 'when default store does not have default_country_id' do
+          before do
+            Spree::Store.default.update(default_country_id: nil)
+            visit spree.new_admin_store_path
+          end
+
+          it 'sets default country of new Store to the default store\'s default country' do
+            expect(page).to have_field('store_default_country_id', text: 'United States')
+          end
+        end
+      end
     end
 
     it 'saving store' do


### PR DESCRIPTION
https://getvendo.atlassian.net/browse/VEN-290