### PR TITLE
Add indication tab to selected menu item.

### DIFF
--- a/app/assets/stylesheets/spree/backend/components/_sidebar.scss
+++ b/app/assets/stylesheets/spree/backend/components/_sidebar.scss
@@ -38,6 +38,18 @@ ul.active-option {
   .drop-menu-indicator {
     transform: rotate(90deg);
   }
+
+  li.selected::before {
+    display: block;
+    content: '';
+    background-color: theme-color('primary');
+    width: 5px;
+    position: absolute;
+    left: -$border-radius;
+    height: 100%;
+    top: 0;
+    border-radius: 0 $border-radius $border-radius 0;
+  }
 }
 
 ul.nav-sidebar {


### PR DESCRIPTION
Adds a side tab to man menu items as additional indicator to active menu.

Standard Item
<img width="253" alt="Screenshot 2022-01-16 at 16 55 34" src="https://user-images.githubusercontent.com/1240766/149669717-7b4355e1-e19f-426f-9312-5f2f2ea31538.png">

Nested Item
<img width="250" alt="Screenshot 2022-01-16 at 16 55 28" src="https://user-images.githubusercontent.com/1240766/149669732-77c3227e-92a3-4771-884d-20d78b401d81.png">

