### PR TITLE
Fix Main Menu Styling 

### DIFF
--- a/app/assets/stylesheets/spree/backend/components/_sidebar.scss
+++ b/app/assets/stylesheets/spree/backend/components/_sidebar.scss
@@ -7,6 +7,7 @@ aside#main-sidebar {
   height: 100%;
   transition: 0.3s ease;
   z-index: 1041;
+  background: white;
 
   .text-muted {
     color: #5C5F62 !important;

--- a/app/views/spree/admin/shared/_main_menu.html.erb
+++ b/app/views/spree/admin/shared/_main_menu.html.erb
@@ -1,4 +1,4 @@
-<nav class="py-3 px-1">
+<nav class="pb-3 px-1">
   <div class="text-right d-lg-none pl-3 py-2 border-bottom d-flex align-items-center">
     <div class="d-flex flex-grow-1 text-primary">
       <%= svg_icon name: "spree-logo.svg", width: '70', height: '30' %>


### PR DESCRIPTION
Transparent menu doesn't work on slide out mode.
<img width="912" alt="Screenshot 2022-01-16 at 17 06 11" src="https://user-images.githubusercontent.com/1240766/149670129-fae3e7a1-5ee1-40ba-b1f7-80d9d1215df5.png">

Remove excess padding from top of menu.