### PR TITLE
Only pad menu on large screens.

### DIFF
--- a/app/views/spree/admin/shared/_main_menu.html.erb
+++ b/app/views/spree/admin/shared/_main_menu.html.erb
@@ -1,4 +1,4 @@
-<nav class="pb-3 px-1">
+<nav class="pb-3 pt-lg-3 px-1">
   <div class="text-right d-lg-none pl-3 py-2 border-bottom d-flex align-items-center">
     <div class="d-flex flex-grow-1 text-primary">
       <%= svg_icon name: "spree-logo.svg", width: '70', height: '30' %>


### PR DESCRIPTION
The mobile menu should have no toppings padding, but the desktop should.

Ideally this should be calculated based off the nav bar height rather than a set bootstrap padding but at the moment there is no set nav bar height.