### PR TITLE
Fix/side scroll

### DIFF
--- a/app/helpers/spree/admin/navigation_helper.rb
+++ b/app/helpers/spree/admin/navigation_helper.rb
@@ -306,7 +306,7 @@ module Spree
       end
 
       def page_header_back_button(url)
-        link_to url, class: 'btn btn-outline-info mr-3 pr-1' do
+        link_to url, class: 'btn btn-outline-info mr-3 pr-1 align-bottom' do
           svg_icon name: 'chevron-left.svg', width: 15, height: 15
         end
       end

--- a/app/views/spree/admin/orders/index.html.erb
+++ b/app/views/spree/admin/orders/index.html.erb
@@ -111,17 +111,8 @@
       </tbody>
     </table>
   </div>
-  <button class="nav-x_Advancer nav-x_Advancer_Left" type="button">
-    <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-      <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z" />
-    </svg>
-  </button>
 
-  <button class="nav-x_Advancer nav-x_Advancer_Right" type="button">
-    <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-      <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z" />
-    </svg>
-  </button>
+  <%= render partial: 'spree/admin/shared/ui_elements/side_scroll_buttons' %>
 </div>
 <% else %>
   <div class="text-center no-objects-found m-5">

--- a/app/views/spree/admin/shared/_content_header.html.erb
+++ b/app/views/spree/admin/shared/_content_header.html.erb
@@ -16,9 +16,7 @@
           <div class="page-actions pl-0 pr-0 d-none d-lg-flex" data-hook="toolbar">
             <%= yield :page_actions %>
           </div>
-        <% end %>
 
-        <% if content_for?(:page_actions) %>
           <div class="d-flex d-lg-none justify-content-end m-0 p-0">
             <button type="button"
                     id="contextual-menu-toggle"

--- a/app/views/spree/admin/shared/_content_header.html.erb
+++ b/app/views/spree/admin/shared/_content_header.html.erb
@@ -35,22 +35,12 @@
       <% if content_for?(:page_tabs) %>
         <div class="row my-2 mb-3 pb-1 pt-1 align-items-center" data-nav-x-wrapper>
           <div data-nav-x-container class="w-100">
-            <ul id="spreePageTabs" class="nav nav-pills w-100 flex-nowrap" data-nav-x-content>
+            <ul id="spreePageTabs" class="nav nav-pills flex-nowrap" data-nav-x-content>
               <%= yield :page_tabs %>
             </ul>
           </div>
 
-          <button class="nav-x_Advancer nav-x_Advancer_Left" type="button">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-              <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z" />
-            </svg>
-          </button>
-
-          <button class="nav-x_Advancer nav-x_Advancer_Right" type="button">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-              <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z" />
-            </svg>
-          </button>
+          <%= render partial: 'spree/admin/shared/ui_elements/side_scroll_buttons' %>
         </div>
       <% end %>
 

--- a/app/views/spree/admin/shared/ui_elements/_side_scroll_buttons.html.erb
+++ b/app/views/spree/admin/shared/ui_elements/_side_scroll_buttons.html.erb
@@ -1,0 +1,11 @@
+<button class="nav-x_Advancer nav-x_Advancer_Left" type="button">
+  <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+    <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z" />
+  </svg>
+</button>
+
+<button class="nav-x_Advancer nav-x_Advancer_Right" type="button">
+  <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+    <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z" />
+  </svg>
+</button>


### PR DESCRIPTION
- Remove width 100% (w-100) from side scroll content to allow overflow right to pick up.
- Move buttons to their own partial for use in several locations and editable in one location.