### PR TITLE
Fix sideways over scroll on edit product details page.

### DIFF
--- a/app/views/spree/admin/products/_form.html.erb
+++ b/app/views/spree/admin/products/_form.html.erb
@@ -28,11 +28,11 @@
     </div>
 
     <div class="col-12 col-md-4" data-hook="admin_product_form_right">
-      <div data-hook="new_product_status" class="omega two columns">
+      <div data-hook="new_product_status">
         <%= f.field_container :status do %>
           <%= f.label :status, Spree.t(:status) %>
           <% options = ['draft', 'active', 'archived'].each_slice(1) %>
-          <% select_html = { class: 'select2 w-100',
+          <% select_html = { class: 'select2',
                              data: { action: 'change->product-edit#switchAvailabilityDatesFields', 'product-edit-target': 'status' },
                              disabled: cannot?(:change_status, @product) } %>
           <%= f.select(:status, options, { selected: @product.status }, select_html) %>


### PR DESCRIPTION
There is a UI issue on the product edit details,  if you scroll left to right the main content side scrolls under the menu.

<img width="1439" alt="Screenshot 2022-01-25 at 22 06 10" src="https://user-images.githubusercontent.com/1240766/151067639-d7d23c5b-88d9-4385-8eaf-167afad5b7ad.png">

Issue was caused by the new select2 `w-100` class added.