### PR TITLE
fix: bump spree version to 4.4.0

### DIFF
--- a/spree_backend.gemspec
+++ b/spree_backend.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree', ">= 4.4.0.rc1"
+  s.add_dependency 'spree', ">= 4.4.0"
 
   s.add_dependency 'babel-transpiler', '~> 0.7'
   s.add_dependency 'bootstrap',        '~> 4.0'


### PR DESCRIPTION
Currently under the gemspec file, spree version is set to `>=4.4.0.rc1`

This is causing bundle install to fail since `4.4.0<4.4.0.rc1`

https://github.com/spree/spree_backend/blob/4f35aaea949e172ec951ba515d84edd9f530e839/spree_backend.gemspec#L28