### PR TITLE
changes add for state field!

### DIFF
--- a/app/assets/javascripts/spree/backend/address_states.es6
+++ b/app/assets/javascripts/spree/backend/address_states.es6
@@ -24,6 +24,7 @@ function updateAddressState(region, successCallback) {
               stateSelect.append(opt).trigger('change')
             })
             stateSelect.prop('disabled', false).show()
+            stateSelect.select2()
             if (stateSelectValue !== undefined) {
               stateSelect.val(stateSelectValue).trigger('change')
             }

--- a/app/assets/javascripts/spree/backend/address_states.es6
+++ b/app/assets/javascripts/spree/backend/address_states.es6
@@ -14,6 +14,7 @@ function updateAddressState(region, successCallback) {
         response.json().then((json) => {
           const states = json.included
           const statesRequired = json.data.attributes.states_required
+          const stateSelectValue = stateSelect.val();
           if (states.length > 0) {
             stateSelect.html('')
             $.each(states, function (_pos, state) {
@@ -23,7 +24,9 @@ function updateAddressState(region, successCallback) {
               stateSelect.append(opt).trigger('change')
             })
             stateSelect.prop('disabled', false).show()
-            stateSelect.select2()
+            if (stateSelectValue !== undefined) {
+              stateSelect.val(stateSelectValue).trigger('change')
+            }
             stateInput.hide().prop('disabled', true)
             stateContainer.show()
           } else {


### PR DESCRIPTION
If A customer has in his address details like this B-01/455, Palam Vihar, New Delhi, India 110014. according to this information, the zipcode field gets data as "110014", the city field is get the data as "New Delhi", the country field should get data as "India" and so on.
The Customer details edit page should show the fields according to the corresponding data value of it saved on the database.

Fixes https://github.com/spree/spree/issues/11624