### PR TITLE
Add a min height for navbar to meet menu.

### DIFF
--- a/app/assets/stylesheets/spree/backend/components/_navbar.scss
+++ b/app/assets/stylesheets/spree/backend/components/_navbar.scss
@@ -1,5 +1,7 @@
 .header {
   .navbar {
+    min-height:54px;
+
     a:hover {
       text-decoration: none;
     }


### PR DESCRIPTION
Use min-height for nav bar so hat it meet the menu top, but can be larger for other contents.