### PR TITLE
Drop the pre-order status

### DIFF
--- a/app/helpers/spree/admin/products_helper.rb
+++ b/app/helpers/spree/admin/products_helper.rb
@@ -8,8 +8,6 @@ module Spree
 
         if product.available?
           Spree.t('admin.product.active')
-        elsif product.available_on&.future?
-          Spree.t('admin.product.pre_order')
         else
           Spree.t('admin.product.draft')
         end

--- a/spec/helpers/spree/admin/products_helper_spec.rb
+++ b/spec/helpers/spree/admin/products_helper_spec.rb
@@ -33,17 +33,6 @@ describe Spree::Admin::ProductsHelper, type: :helper do
       end
     end
 
-    context 'product will be available soon' do
-      before do
-        product.status = 'draft'
-        product.available_on = 1.month.from_now
-      end
-
-      it 'has Pre-order status' do
-        expect(status).to eq(Spree.t('admin.product.pre_order'))
-      end
-    end
-
     context 'draft product' do
       before do
         product.status = 'draft'


### PR DESCRIPTION
We should only show product status, not available on logic here