### PR TITLE
VEN-356 Refactor out MenuItem Icon upload form

### DIFF
--- a/app/views/spree/admin/menu_items/_form.html.erb
+++ b/app/views/spree/admin/menu_items/_form.html.erb
@@ -52,27 +52,14 @@
           <% end %>
 
           <% @menu_item.build_icon unless @menu_item.icon %>
-            <%= f.fields_for :icon do |icon_field| %>
-              <%= f.field_container :icon_attachment do %>
-                <% unless @menu_item.icon.new_record? %>
-                  <div id="menuItemImgContainer" class="my-3 ">
-                    <%= image_tag(main_app.cdn_image_url(@menu_item.icon.attachment)) %>
-                    <%= link_to Spree.t(:remove_image), remove_icon_admin_menu_menu_item_path(@menu, @menu_item), method: :delete %>
-                  </div>
-                <% end %>
-              <div id="<% unless @menu_item.icon.new_record? %>MenuItemImageButton<% end %>">
-                <%= icon_field.file_field :attachment %>
-              </div>
-              <small class="form-text text-muted">
-                <%= raw Spree.t('admin.navigation.image_info') %>
-              </small>
-            <% end %>
+          <%= f.fields_for :icon do |ff| %>
+            <%= render partial: 'icon_upload_form', locals: { f: f, ff: ff } %>
 
             <%= f.field_container :icon_alt do %>
               <% unless @menu_item.icon.new_record? %>
                 <div class="form-group my-3">
-                  <%= icon_field.label :alt, Spree.t('admin.navigation.image_alt_text') %>
-                  <%= icon_field.text_field :alt, class: 'form-control' %>
+                  <%= ff.label :alt, Spree.t('admin.navigation.image_alt_text') %>
+                  <%= ff.text_field :alt, class: 'form-control' %>
                 </div>
               <% end %>
             <% end %>

--- a/app/views/spree/admin/menu_items/_icon_upload_form.html.erb
+++ b/app/views/spree/admin/menu_items/_icon_upload_form.html.erb
@@ -1,0 +1,14 @@
+<%= f.field_container :icon_attachment do %>
+  <% unless @menu_item.icon.new_record? %>
+    <div id="menuItemImgContainer" class="my-3 ">
+      <%= image_tag(main_app.cdn_image_url(@menu_item.icon.attachment)) %>
+      <%= link_to Spree.t(:remove_image), remove_icon_admin_menu_menu_item_path(@menu, @menu_item), method: :delete %>
+    </div>
+  <% end %>
+  <div id="<% unless @menu_item.icon.new_record? %>MenuItemImageButton<% end %>">
+    <%= ff.file_field :attachment %>
+  </div>
+<% end %>
+<small class="form-text text-muted">
+  <%= raw Spree.t('admin.navigation.image_info') %>
+</small>


### PR DESCRIPTION
https://getvendo.atlassian.net/browse/VEN-356

Still trying to figure out some problems with caused in `sortable_tree/_menu` => `main_app.cdn_image_url(item.icon.attachment)`. When I have a Spree::Icon model and attachment in it `cdn_image` does not work. The attachment has no `.blob` or other attributes associated with ActiveStorage, when uploaded through a service