### PR TITLE
Fix missing scroll right button off nav-x tabs.

### DIFF
--- a/app/views/spree/admin/shared/_content_header.html.erb
+++ b/app/views/spree/admin/shared/_content_header.html.erb
@@ -35,7 +35,7 @@
       <% if content_for?(:page_tabs) %>
         <div class="row my-2 mb-3 pb-1 pt-1 align-items-center" data-nav-x-wrapper>
           <div data-nav-x-container class="w-100">
-            <ul id="spreePageTabs" class="nav nav-pills w-100 flex-nowrap" data-nav-x-content>
+            <ul id="spreePageTabs" class="nav nav-pills flex-nowrap" data-nav-x-content>
               <%= yield :page_tabs %>
             </ul>
           </div>


### PR DESCRIPTION
Fix missing scroll right button on horizontal scrolling buttons.

(The `data-nav-x-content` content must tightly wrap its child items, not span 100% width of its parent.)

<img width="717" alt="Screenshot 2022-02-03 at 23 09 10" src="https://user-images.githubusercontent.com/1240766/152444496-945f76d2-7b43-40a8-8ed7-ed54b958dcf0.png">