### PR TITLE
Remove col-12 to Stop Overflowing Content.

### DIFF
--- a/app/views/spree/admin/cms_pages/_form.html.erb
+++ b/app/views/spree/admin/cms_pages/_form.html.erb
@@ -3,7 +3,7 @@
     <div class="col-12">
       <div class="card sp-card">
         <% unless %w[new create].include? controller.action_name %>
-        <div class="card-header col-12">
+        <div class="card-header">
           <div class="row no-gutters pb-0">
             <div class="col d-flex justify-content-start align-items-center">
               <%= f.field_container :visible, class: ['pb-0 mb-0'] do %>


### PR DESCRIPTION
Before
<img width="1198" alt="Screenshot 2022-02-21 at 22 19 22" src="https://user-images.githubusercontent.com/1240766/155032650-333545eb-6451-48a9-8567-1e5312e26c5d.png">

After:
<img width="1189" alt="Screenshot 2022-02-21 at 22 19 02" src="https://user-images.githubusercontent.com/1240766/155032666-a9250264-26d5-480a-a9e8-0962abf517b7.png">

