### PR TITLE
Add ability to send turbo stream flash notices.

### DIFF
--- a/app/controllers/spree/admin/base_controller.rb
+++ b/app/controllers/spree/admin/base_controller.rb
@@ -61,10 +61,11 @@ module Spree
         Spree.t(event_sym, resource: resource_desc)
       end
 
-      def render_flash(message:, kind:)
+      def render_flash(message:, kind: 'success')
         respond_to do |format|
           format.turbo_stream do
-            render turbo_stream: turbo_stream.append('FlashAlertsContainer', partial: 'spree/admin/shared/flash_notice', locals: { message: message, kind: kind })
+            render turbo_stream: turbo_stream.append('FlashAlertsContainer', partial: 'spree/admin/shared/flash_notice',
+                                                                             locals: { message: message, kind: kind })
           end
         end
       end
@@ -93,9 +94,7 @@ module Spree
       end
 
       def admin_oauth_application
-        @admin_oauth_application ||= begin
-          Spree::OauthApplication.find_or_create_by!(name: 'Admin Panel', scopes: 'admin', redirect_uri: '')
-        end
+        @admin_oauth_application ||= Spree::OauthApplication.find_or_create_by!(name: 'Admin Panel', scopes: 'admin', redirect_uri: '')
       end
 
       # FIXME: auto-expire this token

--- a/app/controllers/spree/admin/base_controller.rb
+++ b/app/controllers/spree/admin/base_controller.rb
@@ -61,6 +61,14 @@ module Spree
         Spree.t(event_sym, resource: resource_desc)
       end
 
+      def render_flash(kind, message)
+        respond_to do |format|
+          format.turbo_stream do
+            render turbo_stream: turbo_stream.append('FlashAlertsContainer', partial: 'spree/admin/shared/flash_notice', locals: { message: message, kind: kind })
+          end
+        end
+      end
+
       def render_js_for_destroy
         render partial: '/spree/admin/shared/destroy'
       end

--- a/app/controllers/spree/admin/base_controller.rb
+++ b/app/controllers/spree/admin/base_controller.rb
@@ -61,7 +61,7 @@ module Spree
         Spree.t(event_sym, resource: resource_desc)
       end
 
-      def render_flash(kind, message)
+      def render_flash(message:, kind:)
         respond_to do |format|
           format.turbo_stream do
             render turbo_stream: turbo_stream.append('FlashAlertsContainer', partial: 'spree/admin/shared/flash_notice', locals: { message: message, kind: kind })

--- a/app/javascript/spree/dashboard/controllers/flash_notice_controller.js
+++ b/app/javascript/spree/dashboard/controllers/flash_notice_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = {
+    kind: String,
+    content: String
+  }
+
+  connect () {
+    show_flash(this.kindValue, this.contentValue)
+  }
+}

--- a/app/javascript/spree/dashboard/index.js
+++ b/app/javascript/spree/dashboard/index.js
@@ -46,6 +46,9 @@ application.register("clipboard", ClipboardController)
 import ProductEditController from "./controllers/product_edit_controller"
 application.register("product-edit", ProductEditController)
 
+import FlashNoticeController from "./controllers/flash_notice_controller"
+application.register("flash-notice", FlashNoticeController)
+
 import * as RequestUtility from "./utilities/request_utility"
 
 //

--- a/app/views/spree/admin/shared/_flash_notice.html.erb
+++ b/app/views/spree/admin/shared/_flash_notice.html.erb
@@ -1,0 +1,6 @@
+<span data-controller="flash-notice"
+      data-flash-notice-kind-value="<%= kind %>"
+      data-flash-notice-content-value="<%= message %>">
+
+  <%= message %>
+</span>


### PR DESCRIPTION
This PR allows you to send a flash notice to the DOM through a turbo stream.

```ruby
# Example use
          if @product.save
              render_flash(message: 'Products successfully added to taxons', kind: 'success')
          end
```

When the partial is appended to the FlashAlertsContainer Stimulus registeres the controller connect and fires the flash alert.