### PR TITLE
Fix: Adding a new property with the same name to a product omits vali…

### DIFF
--- a/app/controllers/spree/admin/products_controller.rb
+++ b/app/controllers/spree/admin/products_controller.rb
@@ -32,7 +32,7 @@ module Spree
           params[:product][:option_type_ids] = params[:product][:option_type_ids].reject(&:empty?)
         end
         invoke_callbacks(:update, :before)
-        if @object.update(permitted_resource_params)
+        if @object.update(sanitized_resource_params)
           set_current_store
           invoke_callbacks(:update, :after)
           flash[:success] = flash_message_for(@object, :successfully_updated)
@@ -194,6 +194,23 @@ module Spree
         else
           super
         end
+      end
+
+      def sanitized_resource_params
+        return permitted_resource_params if permitted_resource_params[:product_properties_attributes].nil?
+
+        taken_property_names = []
+        unique_product_properties_attributes = permitted_resource_params[:product_properties_attributes].select do |_, property_attributes|
+          if taken_property_names.include?(property_attributes[:property_name])
+            false
+          else
+            taken_property_names << property_attributes[:property_name]
+            true
+          end
+        end
+        sanitized_resource_params = permitted_resource_params
+        sanitized_resource_params[:product_properties_attributes] = unique_product_properties_attributes
+        sanitized_resource_params
       end
 
       private

--- a/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spec/controllers/spree/admin/products_controller_spec.rb
@@ -70,6 +70,15 @@ describe Spree::Admin::ProductsController, type: :controller do
         expect(flash[:success]).to eq("Product #{product.name.inspect} has been successfully updated!")
       end
     end
+
+    context 'adding the same property to a product twice' do
+      let(:product_params) { { product_properties_attributes: { '1' => { property_name: 'Foo', value: 'bar' }, '2' => { property_name: 'Foo', value: 'bar2' } } } }
+
+      specify do
+        expect { send_request }.not_to raise_error
+        expect(flash[:success]).to eq("Product #{product.name.inspect} has been successfully updated!")
+      end
+    end
   end
 
   # regression test for #801


### PR DESCRIPTION
…dation and throws error 'PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_spree_product_properties_on_property_id_and_product_id"'