### PR TITLE
VEN-472 Allow selected option for menu tabs

### DIFF
--- a/app/helpers/spree/admin/navigation_helper.rb
+++ b/app/helpers/spree/admin/navigation_helper.rb
@@ -38,13 +38,15 @@ module Spree
 
         css_classes = ['sidebar-menu-item d-block w-100 position-relative']
 
-        selected = if options[:match_path].is_a? Regexp
-                     request.fullpath =~ options[:match_path]
-                   elsif options[:match_path]
-                     request.fullpath.starts_with?("#{spree.admin_path}#{options[:match_path]}")
-                   else
-                     args.include?(controller.controller_name.to_sym)
-                   end
+        if (selected = options[:selected]).nil?
+          selected = if options[:match_path].is_a? Regexp
+                       request.fullpath =~ options[:match_path]
+                     elsif options[:match_path]
+                       request.fullpath.starts_with?("#{spree.admin_path}#{options[:match_path]}")
+                     else
+                       args.include?(controller.controller_name.to_sym)
+                     end
+        end
 
         link = if options[:icon]
                  link_to_with_icon(

--- a/spec/helpers/spree/admin/navigation_helper_spec.rb
+++ b/spec/helpers/spree/admin/navigation_helper_spec.rb
@@ -33,47 +33,57 @@ describe Spree::Admin::NavigationHelper, type: :helper do
     end
 
     describe 'selection' do
-      context 'when match_path option is not supplied' do
-        subject(:tab) { helper.tab(:orders) }
+      context 'when selected option is supplied' do
+        subject(:tab) { helper.tab(:orders, selected: true) }
 
-        it 'is selected if the controller matches' do
-          allow(controller).to receive(:controller_name).and_return('orders')
-          expect(subject).to include('selected')
-        end
-
-        it 'is not selected if the controller does not match' do
-          allow(controller).to receive(:controller_name).and_return('bonobos')
-          expect(subject).not_to include('selected')
+        it 'includes selected' do
+          expect(tab).to include('selected')
         end
       end
 
-      context 'when match_path option is supplied' do
-        before do
-          allow(helper).to receive(:request).and_return(double(ActionDispatch::Request, fullpath: '/admin/orders/edit/1'))
+      context 'when selected option is not supplied' do
+        subject(:tab) { helper.tab(:orders) }
+
+        context 'when match_path option is not supplied' do
+          it 'is selected if the controller matches' do
+            allow(controller).to receive(:controller_name).and_return('orders')
+            expect(subject).to include('selected')
+          end
+
+          it 'is not selected if the controller does not match' do
+            allow(controller).to receive(:controller_name).and_return('bonobos')
+            expect(subject).not_to include('selected')
+          end
         end
 
-        it 'is selected if the fullpath matches' do
-          allow(controller).to receive(:controller_name).and_return('bonobos')
-          tab = helper.tab(:orders, label: 'delivered orders', match_path: '/orders')
-          expect(tab).to include('selected')
-        end
+        context 'when match_path option is supplied' do
+          before do
+            allow(helper).to receive(:request).and_return(double(ActionDispatch::Request, fullpath: '/admin/orders/edit/1'))
+          end
 
-        it 'is selected if the fullpath matches a regular expression' do
-          allow(controller).to receive(:controller_name).and_return('bonobos')
-          tab = helper.tab(:orders, label: 'delivered orders', match_path: /orders$|orders\//)
-          expect(tab).to include('selected')
-        end
+          it 'is selected if the fullpath matches' do
+            allow(controller).to receive(:controller_name).and_return('bonobos')
+            tab = helper.tab(:orders, label: 'delivered orders', match_path: '/orders')
+            expect(tab).to include('selected')
+          end
 
-        it 'is not selected if the fullpath does not match' do
-          allow(controller).to receive(:controller_name).and_return('bonobos')
-          tab = helper.tab(:orders, label: 'delivered orders', match_path: '/shady')
-          expect(tab).not_to include('selected')
-        end
+          it 'is selected if the fullpath matches a regular expression' do
+            allow(controller).to receive(:controller_name).and_return('bonobos')
+            tab = helper.tab(:orders, label: 'delivered orders', match_path: /orders$|orders\//)
+            expect(tab).to include('selected')
+          end
 
-        it 'is not selected if the fullpath does not match a regular expression' do
-          allow(controller).to receive(:controller_name).and_return('bonobos')
-          tab = helper.tab(:orders, label: 'delivered orders', match_path: /shady$|shady\//)
-          expect(tab).not_to include('selected')
+          it 'is not selected if the fullpath does not match' do
+            allow(controller).to receive(:controller_name).and_return('bonobos')
+            tab = helper.tab(:orders, label: 'delivered orders', match_path: '/shady')
+            expect(tab).not_to include('selected')
+          end
+
+          it 'is not selected if the fullpath does not match a regular expression' do
+            allow(controller).to receive(:controller_name).and_return('bonobos')
+            tab = helper.tab(:orders, label: 'delivered orders', match_path: /shady$|shady\//)
+            expect(tab).not_to include('selected')
+          end
         end
       end
     end


### PR DESCRIPTION
https://getvendo.atlassian.net/browse/VEN-472

Currently we determine if a tab is active by the path of the request or the controller name (if `match_path` is not supplied). It is good to have a `selected` option when we want custom logic for if a tab should be active.