### PR TITLE
Ensure Safari 14.0 compatibility

### DIFF
--- a/app/javascript/spree/dashboard/controllers/clipboard_controller.js
+++ b/app/javascript/spree/dashboard/controllers/clipboard_controller.js
@@ -1,7 +1,9 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = [ "source" ]
+  static get targets() {
+    return ["source"]
+  }
 
   copy(event) {
     console.log(event)

--- a/app/javascript/spree/dashboard/controllers/password_toggle_controller.js
+++ b/app/javascript/spree/dashboard/controllers/password_toggle_controller.js
@@ -1,7 +1,9 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["unhide"]
+  static get targets() {
+    return ["unhide"]
+  }
 
   password(e) {
     if (this.unhideTarget.type === "password") {

--- a/app/javascript/spree/dashboard/controllers/product_edit_controller.js
+++ b/app/javascript/spree/dashboard/controllers/product_edit_controller.js
@@ -1,7 +1,9 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["availableOn", "makeActiveAt", "discontinueOn", "status"]
+  static get targets() {
+    return ["availableOn", "makeActiveAt", "discontinueOn", "status"]
+  }
 
   initialize() {
     $(this.statusTarget).on("select2:select", function (e) {

--- a/app/javascript/spree/dashboard/controllers/sortable_tree_controller.js
+++ b/app/javascript/spree/dashboard/controllers/sortable_tree_controller.js
@@ -3,7 +3,9 @@ import { Sortable } from "sortablejs"
 import { patch } from "../utilities/request_utility"
 
 export default class extends Controller {
-  static values = { handle: String }
+  static get values() {
+    return { handle: String }
+  }
 
   connect() {
     const itemSortable = {

--- a/app/javascript/spree/dashboard/controllers/upload_button_controller.js
+++ b/app/javascript/spree/dashboard/controllers/upload_button_controller.js
@@ -1,7 +1,9 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = [ "uploadButton"]
+  static get targets() {
+    return ["uploadButton"]
+  }
 
   initialize() {
     this.uploadButtonTarget.disabled = true

--- a/app/javascript/spree/dashboard/controllers/webhooks_subscriber_events_controller.js
+++ b/app/javascript/spree/dashboard/controllers/webhooks_subscriber_events_controller.js
@@ -1,7 +1,9 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = [ "eventsCheckboxesContainer", "subscribeToAll" ]
+  static get targets() {
+    return ["eventsCheckboxesContainer", "subscribeToAll"]
+  }
 
   hideCheckboxes() {
     this.eventsCheckboxesContainerTarget.hidden = true


### PR DESCRIPTION
The spree_backend does not work on Safari 14.0.1 (2020) with the new @hotwire/stimulus controllers. The `static targets = ` syntax throws an error. There is an alternative way according to this issue https://github.com/hotwired/stimulus/issues/366#issuecomment-761303692

Tested this locally on both Safari 14.0.1 and Safari 14.1.2 and latest Chrome and it works.

Would be great if you could merge this swiftly and update the npm `@spree/dashboard` package, as it's quite cumbersome to integrate a forked version.

