### PR TITLE
Fix CSRF security issue in adjustments admin panel

### DIFF
--- a/app/views/spree/admin/adjustments/_adjustments_table.html.erb
+++ b/app/views/spree/admin/adjustments/_adjustments_table.html.erb
@@ -21,10 +21,10 @@
   <div class="card-footer">
     <div class="row text-center pb-0">
       <div class="col-12 col-lg-6">
-        <%= button_to Spree.t(:open_all_adjustments), open_adjustments_admin_order_path(@order), method: :get, class: "btn btn-success" %>
+        <%= button_to Spree.t(:open_all_adjustments), open_adjustments_admin_order_path(@order), method: :put, class: "btn btn-success" %>
       </div>
       <div class="col-12 col-lg-6">
-        <%= button_to Spree.t(:close_all_adjustments), close_adjustments_admin_order_path(@order), method: :get, class: "btn btn-danger" %>
+        <%= button_to Spree.t(:close_all_adjustments), close_adjustments_admin_order_path(@order), method: :put, class: "btn btn-danger" %>
       </div>
     </div>
   </div>

--- a/app/views/spree/admin/orders/_order_actions.html.erb
+++ b/app/views/spree/admin/orders/_order_actions.html.erb
@@ -12,6 +12,7 @@
   <% if (can? :update, @order) && @order.some_digital? %>
     <%= button_link_to Spree.t('admin.digitals.reset_download_links'),
         reset_digitals_admin_order_url(@order),
+        method: :put,
         icon: 'hdd.svg' %>
   <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,14 +78,14 @@ Spree::Core::Engine.add_routes do
       member do
         get :cart
         post :resend
-        get :open_adjustments
-        get :close_adjustments
+        put :open_adjustments
+        put :close_adjustments
         put :approve
         put :cancel
         put :resume
         get :channel
         put :set_channel
-        get :reset_digitals
+        put :reset_digitals
       end
 
       resources :state_changes, only: [:index]

--- a/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -175,12 +175,12 @@ describe Spree::Admin::OrdersController, type: :controller do
       end
 
       it 'changes all the closed adjustments to open' do
-        post :open_adjustments, params: { id: order.number }
+        put :open_adjustments, params: { id: order.number }
         expect(adjustments.map(&:state)).to eq(['open'])
       end
 
       it 'sets the flash success message' do
-        post :open_adjustments, params: { id: order.number }
+        put :open_adjustments, params: { id: order.number }
         expect(flash[:success]).to eql('All adjustments successfully opened!')
       end
 
@@ -190,7 +190,7 @@ describe Spree::Admin::OrdersController, type: :controller do
         end
 
         it 'redirects back' do
-          post :open_adjustments, params: { id: order.number }
+          put :open_adjustments, params: { id: order.number }
           expect(response).to redirect_to(spree.admin_url(host: 'http://test.host'))
         end
       end
@@ -201,7 +201,7 @@ describe Spree::Admin::OrdersController, type: :controller do
         end
 
         it 'refirects to fallback location' do
-          post :open_adjustments, params: { id: order.number }
+          put :open_adjustments, params: { id: order.number }
           expect(response).to redirect_to(admin_order_adjustments_url(order))
         end
       end
@@ -223,12 +223,12 @@ describe Spree::Admin::OrdersController, type: :controller do
       end
 
       it 'changes all the open adjustments to closed' do
-        post :close_adjustments, params: { id: order.number }
+        put :close_adjustments, params: { id: order.number }
         expect(adjustments.map(&:state)).to eq(['closed'])
       end
 
       it 'sets the flash success message' do
-        post :close_adjustments, params: { id: order.number }
+        put :close_adjustments, params: { id: order.number }
         expect(flash[:success]).to eql('All adjustments successfully closed!')
       end
 
@@ -238,7 +238,7 @@ describe Spree::Admin::OrdersController, type: :controller do
         end
 
         it 'redirects back' do
-          post :close_adjustments, params: { id: order.number }
+          put :close_adjustments, params: { id: order.number }
           expect(response).to redirect_to(spree.admin_url(host: 'http://test.host'))
         end
       end
@@ -249,7 +249,7 @@ describe Spree::Admin::OrdersController, type: :controller do
         end
 
         it 'refirects to fallback location' do
-          post :close_adjustments, params: { id: order.number }
+          put :close_adjustments, params: { id: order.number }
           expect(response).to redirect_to(admin_order_adjustments_url(order))
         end
       end


### PR DESCRIPTION
The routes for `admin/orders/{orderId}/open_adjustments` , `admin/orders/{orderId}/close_adjustments` , `admin/orders/{orderId}/reset_digitals` currently use GET method, even though they cause state changes on the backend.

This creates a CSRF risk, if an external page loads these paths while the admin is signed in. 
I've changed these routes to use PUT, which is by default protected by CSRF token.