### PR TITLE
Fix The select2('destroy') method was called on an element that is not using Select2

### DIFF
--- a/app/assets/javascripts/spree/backend/global/flatpickr.es6
+++ b/app/assets/javascripts/spree/backend/global/flatpickr.es6
@@ -23,7 +23,9 @@ document.addEventListener("spree:load", function() {
 
 document.addEventListener("turbo:before-cache", function() {
   document.querySelectorAll('.datePickerFrom, .datePickerTo, .datepicker').forEach(function(element) {
-    element._flatpickr.destroy()
+    if (element._flatpickr) {
+      element._flatpickr.destroy()
+    }
   })
 })
 

--- a/app/assets/javascripts/spree/backend/global/select2_autocomplete.es6
+++ b/app/assets/javascripts/spree/backend/global/select2_autocomplete.es6
@@ -27,9 +27,19 @@ document.addEventListener("spree:load", function() {
 
 // we need to delete select2 instances before document is saved to cache
 // https://stackoverflow.com/questions/36497723/select2-with-ajax-gets-initialized-several-times-with-rails-turbolinks-events
-document.addEventListener("turbo:before-cache", function() {
-  const select2Autocompletes = document.querySelectorAll('select[data-autocomplete-url-value]')
-  select2Autocompletes.forEach(element => $(element).select2('destroy'))
+document.addEventListener('turbo:before-cache', function () {
+  const select2Autocompletes = document.querySelectorAll(
+    'select[data-autocomplete-url-value]'
+  )
+  select2Autocompletes.forEach(function (element) {
+    const jqElement = $(element)
+    if (
+      jqElement.data('select2') ||
+      jqElement.hasClass('select2-hidden-accessible')
+    ) {
+      jqElement.select2('destroy')
+    }
+  })
 })
 
 // eslint-disable-next-line no-unused-vars

--- a/app/assets/javascripts/spree/backend/spree-select2.js
+++ b/app/assets/javascripts/spree/backend/spree-select2.js
@@ -1,8 +1,28 @@
 // we need to delete select2 instances before document is saved to cache
 // https://stackoverflow.com/questions/36497723/select2-with-ajax-gets-initialized-several-times-with-rails-turbolinks-events
-document.addEventListener("turbo:before-cache", function() {
-  $('select.select2').select2('destroy')
-  $('select.select2-clear').select2('destroy')
+document.addEventListener('turbo:before-cache', function () {
+  const isSelect2JqElement = function (jqElement) {
+    return (
+      jqElement.data('select2') ||
+      jqElement.hasClass('select2-hidden-accessible')
+    )
+  }
+
+  const select2Elements = document.querySelectorAll('select.select2')
+  select2Elements.forEach(function (element) {
+    const jqElement = $(element)
+    if (isSelect2JqElement(jqElement)) {
+      jqElement.select2('destroy')
+    }
+  })
+
+  const select2ClearElements = document.querySelectorAll('select.select2-clear')
+  select2ClearElements.forEach(function (element) {
+    const jqElement = $(element)
+    if (isSelect2JqElement(jqElement)) {
+      jqElement.select2('destroy')
+    }
+  })
 })
 
 document.addEventListener("spree:load", function() {


### PR DESCRIPTION
This should fix the error when we are trying to destroy select2 element's that are not yet initialized