### PR TITLE
Fix select2 search not auto focusing in jQuery 3.6.0

### DIFF
--- a/app/assets/javascripts/spree/backend/spree-select2.js
+++ b/app/assets/javascripts/spree/backend/spree-select2.js
@@ -17,6 +17,12 @@ document.addEventListener("spree:load", function() {
     placeholder: Spree.translations.select_an_option,
     allowClear: true
   })
+
+  if(jQuery().jquery === '3.6.0') {
+    $(document).on('select2:open', () => {
+      document.querySelector('.select2-search__field').focus()
+    });
+  }
 })
 
 $.fn.addSelect2Options = function (data) {


### PR DESCRIPTION
This should fix the select2 search auto focusing when using jQuery 3.6.0