### PR TITLE
Remove "Stores" link in "New store" page navigation

### DIFF
--- a/app/views/spree/admin/stores/new.html.erb
+++ b/app/views/spree/admin/stores/new.html.erb
@@ -1,5 +1,4 @@
 <% content_for :page_title do %>
-  <%= link_to Spree.t(:stores), spree.admin_stores_path(@store) %> /
   <%= Spree.t(:add_store) %>
 <% end %>
 

--- a/spec/features/admin/store_selector_spec.rb
+++ b/spec/features/admin/store_selector_spec.rb
@@ -34,12 +34,12 @@ describe 'Admin store switcher', type: :feature, js: true do
     end
 
     it 'takes you to the add new store page when clicked' do
-      expect(page).not_to have_text('Stores / New Store')
+      expect(page).not_to have_text('New Store')
 
       find('a#storeSelectorDropdown').click
       find('a#addNewStoreLink').click
 
-      expect(page).to have_text('Stores / New Store')
+      expect(page).to have_text('New Store')
     end
   end
 end


### PR DESCRIPTION
The "Stores" page was removed in favor of a dropdown menu, but the /admin/stores/new page still contains a link to it.
I removed it, because clicking on it causes an error which can be confusing.