### PR TITLE
Lock puma version for tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,8 @@ group :test, :development do
   gem 'rubocop-rspec', require: false
   gem 'pry-byebug'
   gem 'webdrivers', '~> 4.1'
-  gem 'puma'
+  # Puma 6.0 causes issues in specs due to conflict with capybara version
+  gem 'puma', '< 6.0'
   gem 'ffaker'
 end
 


### PR DESCRIPTION
Lock puma version to `< 6.0`, as 6.0 is not compatible with the capybara version we use