### PR TITLE
Improve UX of the Option Types admin panel

### DIFF
--- a/app/assets/javascripts/spree/backend/admin.js
+++ b/app/assets/javascripts/spree/backend/admin.js
@@ -39,7 +39,7 @@ document.addEventListener("spree:load", function() {
       var el = $(this)
       el.prop('href', '#')
     })
-    $(target).prepend(newTableRow)
+    $(target).append(newTableRow)
   })
 
   /**

--- a/app/views/spree/admin/option_types/edit.html.erb
+++ b/app/views/spree/admin/option_types/edit.html.erb
@@ -3,12 +3,6 @@
   <%= @option_type.name %>
 <% end %>
 
-<% content_for :page_actions do %>
-  <span id="new_add_option_value" data-hook>
-    <%= button_link_to Spree.t(:add_option_value), "javascript:;", { icon: 'add.svg', :'data-target' => "tbody#sortVert", class: 'btn-success spree_add_fields' } %>
-  </span>
-<% end %>
-
 <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @option_type } %>
 
 <%= form_for [:admin, @option_type] do |f| %>
@@ -43,6 +37,15 @@
               <% end %>
             <% end %>
           </tbody>
+          <tfoot>
+            <tr>
+              <td colspan="4">
+                <div id="new_add_option_value" class="d-flex" data-hook>
+                  <%= button_link_to Spree.t(:add_option_value), "javascript:;", { icon: 'add.svg', :'data-target' => "tbody#sortVert", class: 'btn-success mx-auto spree_add_fields' } %>
+                </div>
+              </td>
+            </tr>
+          </tfoot>
         </table>
       </div>
     </div>


### PR DESCRIPTION
Currently the option to add a new Option Value is available in the top right corner of the page, which is quite far away with the content it modifies and gets confusing. I moved the button right below the list of Option Values, to make it more intuitive.

https://user-images.githubusercontent.com/6420475/196033106-81c4d404-fec8-4247-b43b-5bce4a07c250.mov

