### PR TITLE
Fix Admin::BaseHelper#product_preview_link deprecation warnings

### DIFF
--- a/app/views/spree/admin/images/index.html.erb
+++ b/app/views/spree/admin/images/index.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :page_actions do %>
   <%= yield :page_actions %>
-  <%= product_preview_link(@product) %>
+  <%= external_page_preview_link(@product) %>
   <%= button_link_to(Spree.t(:new_image), spree.new_admin_product_image_url(@product), { class: "btn-success", icon: 'add.svg', id: 'new_image_link' }) if can? :create, Spree::Image %>
 <% end %>
 

--- a/app/views/spree/admin/prices/index.html.erb
+++ b/app/views/spree/admin/prices/index.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :page_actions do %>
   <%= yield :page_actions %>
-  <%= product_preview_link(@product) %>
+  <%= external_page_preview_link(@product) %>
 <% end %>
 
 <form>

--- a/app/views/spree/admin/product_properties/index.html.erb
+++ b/app/views/spree/admin/product_properties/index.html.erb
@@ -2,7 +2,7 @@
 <%= render 'spree/admin/shared/error_messages', target: @product %>
 
 <% content_for :page_actions do %>
-  <%= product_preview_link(@product) %>
+  <%= external_page_preview_link(@product) %>
 
   <%= button_link_to(
     Spree.t(:add_product_properties),

--- a/app/views/spree/admin/products/_add_stock_form.html.erb
+++ b/app/views/spree/admin/products/_add_stock_form.html.erb
@@ -4,7 +4,7 @@
   </h1>
 </div>
 <% content_for :page_actions do %>
-  <%= product_preview_link(@product) %>
+  <%= external_page_preview_link(@product) %>
 <% end %>
 <div class="card-body">
   <%= form_for [:admin, Spree::StockMovement.new], url: admin_stock_items_path do |f| %>

--- a/app/views/spree/admin/products/edit.html.erb
+++ b/app/views/spree/admin/products/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_actions do %>
-  <%= product_preview_link(@product) %>
+  <%= external_page_preview_link(@product) %>
   <% if can?(:create, Spree::Product) %>
     <%= button_link_to Spree.t(:new_product), new_object_url, { class: "btn-success", icon: 'add.svg', id: 'admin_new_product' } %>
   <% end %>

--- a/app/views/spree/admin/variants/index.html.erb
+++ b/app/views/spree/admin/variants/index.html.erb
@@ -66,7 +66,7 @@
   <% end %>
 <% else %>
   <% content_for :page_actions do %>
-    <%= product_preview_link(@product) %>
+    <%= external_page_preview_link(@product) %>
     <%= button_link_to(Spree.t(:new_variant), spree.new_admin_product_variant_url(@product), { icon: 'add.svg', :'data-update' => 'new_variant', class: 'btn-success', id: 'new_var_link' }) if can? :create, Spree::Variant %>
     <%= button_link_to (@deleted == '1' ? Spree.t(:show_active) : Spree.t(:show_deleted)), spree.admin_product_variants_url(@product, { q: { deleted_at_null: @deleted == '1' ? "0" : "1" } }), { class: 'btn-outline-secondary', icon: 'filter.svg' } %>
   <% end %>


### PR DESCRIPTION
- Replace depreciated `#product_preview_link` with `#external_page_preview_link`