### PR TITLE
Do not display canceled orders in Unpaid and Unfulfilled orders

### DIFF
--- a/app/views/spree/admin/orders/index.html.erb
+++ b/app/views/spree/admin/orders/index.html.erb
@@ -18,12 +18,12 @@
   </li>
   <li class="nav-item">
     <%= link_to Spree.t('admin.orders.unpaid'),
-      params.merge({q: {payment_state_not_eq: :paid, completed_at_not_null: 1}}).permit!,
+      params.merge({q: {payment_state_not_eq: :paid, state_eq: 'complete'}}).permit!,
       class: "nav-link #{'active' if params[:q][:payment_state_not_eq] == 'paid'}" %>
   </li>
   <li class="nav-item">
     <%= link_to Spree.t('admin.orders.unfulfilled'),
-      params.merge({q: {shipment_state_not_eq: :shipped, completed_at_not_null: 1}}).permit!,
+      params.merge({q: {shipment_state_not_eq: :shipped, state_eq: 'complete'}}).permit!,
       class: "nav-link #{'active' if params[:q][:shipment_state_not_eq] == 'shipped'}" %>
   </li>
 <% end if @show_only_completed %>


### PR DESCRIPTION
In admin Orders, if you select Unpaid or Unfulfilled, it will show canceled orders, which isn't useful.

Also as discussion, when 'show_only_complete_orders_by_default' backend config is true, was it intended to also show canceled orders (like it is now and which I did not change), or perhaps it was intended not to show canceled orders in this case?