### PR TITLE
Allow for use of settings on payment methods.

### DIFF
--- a/app/helpers/spree/admin/base_helper.rb
+++ b/app/helpers/spree/admin/base_helper.rb
@@ -61,6 +61,10 @@ module Spree
         formatted_option_values
       end
 
+      def path_for(obj)
+        obj.class.name.demodulize.underscore
+      end
+
       def spree_humanize_type(obj)
         last_word = obj.split('::', 10).last
         if last_word.starts_with?('Cms')

--- a/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/app/views/spree/admin/payment_methods/_form.html.erb
@@ -64,13 +64,18 @@
         <div class="card-body">
           <div id="preference-settings" data-hook class="form-group">
             <% unless @object.new_record? %>
-            <% if preference_fields(@object, f).empty? %>
-              <%= Spree.t('no_payment_provider_settings_message') %>
-            <% end %>
-              <%= preference_fields(@object, f) %>
+              <% if @object.respond_to?(:use_settings?) && @object.use_settings? %>
+                <%= render partial: "spree/admin/shared/payment_methods/settings/#{path_for(@object)}", locals: { object: @object, form: f } %>
+              <% else %>
+                <% if preference_fields(@object, f).empty? %>
+                  <%= Spree.t('no_payment_provider_settings_message') %>
+                <% end %>
 
-              <% if @object.respond_to?(:preferences) %>
-                <div id="gateway-settings-warning" class="info warning"><%= Spree.t(:provider_settings_warning) %></div>
+                <%= preference_fields(@object, f) %>
+
+                <% if @object.respond_to?(:preferences) %>
+                  <div id="gateway-settings-warning" class="info warning"><%= Spree.t(:provider_settings_warning) %></div>
+                <% end %>
               <% end %>
             <% end %>
           </div>


### PR DESCRIPTION
This PR allows developers to use Active Store settings instead of preferences for new payment methods.

Add the following method to your payment method gateway model
```ruby
    # Set to true to load in the view file from views/spree/admin/shared/payment_methods/_your_gateway.html.erb
    def use_settings?
      true
    end
```