### PR TITLE
Always trigger generating slugs when saving translations

### DIFF
--- a/app/controllers/concerns/spree/admin/translatable.rb
+++ b/app/controllers/concerns/spree/admin/translatable.rb
@@ -13,15 +13,16 @@ module Spree
       private
 
       def save_translation_values
-        params[:translation].each do |key, translation|
-          translation.each do |locale, value|
-            I18n.with_locale(locale) do
-              @object.public_send("#{key}=", value)
+        translation_params = params[:translation]
+
+        current_store.supported_locales_list.each do |locale|
+          I18n.with_locale(locale) do
+            translation_params.each do |attribute, translations|
+              @object.public_send("#{attribute}=", translations[locale])
             end
+            @object.save!
           end
         end
-
-        @object.save
       end
     end
   end

--- a/app/views/spree/admin/translations/_form.html.erb
+++ b/app/views/spree/admin/translations/_form.html.erb
@@ -1,10 +1,14 @@
-<%= form_tag nil, { class: 'form-horizontal' } do %>
-  <div class="my-3">
-    <%= render 'spree/admin/translations/translation_table', resource: resource %>
-  </div>
-  <div class="form-actions" data-hook="buttons">
-    <%= button Spree.t('actions.update'), 'update.svg' %>
-    <span class="or"><%= Spree.t(:or) %></span>
-    <%= button_link_to Spree.t('actions.cancel'), admin_product_path(resource), icon: 'delete.svg' %>
-  </div>
+<% if current_store.supported_locales_list.size > 1 %>
+  <%= form_tag nil, { class: 'form-horizontal' } do %>
+    <div class="my-3">
+      <%= render 'spree/admin/translations/translation_table', resource: resource %>
+    </div>
+    <div class="form-actions" data-hook="buttons">
+      <%= button Spree.t('actions.update'), 'update.svg' %>
+      <span class="or"><%= Spree.t(:or) %></span>
+      <%= button_link_to Spree.t('actions.cancel'), admin_product_path(resource), icon: 'delete.svg' %>
+    </div>
+  <% end %>
+<% else %>
+  <%= render partial: 'spree/admin/translations/translations_unavailable' %>
 <% end %>

--- a/app/views/spree/admin/translations/_translations_unavailable.html.erb
+++ b/app/views/spree/admin/translations/_translations_unavailable.html.erb
@@ -1,0 +1,11 @@
+<div class="container">
+  <div class="card">
+    <div class="card-body">
+      <p>To use translations, configure more than one locale for the store.</p>
+
+      <% if can?(:edit, current_store) %>
+        <%= button_link_to('Configure store', spree.edit_admin_store_path(current_store)) %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/spec/features/admin/products/edit/translations_spec.rb
+++ b/spec/features/admin/products/edit/translations_spec.rb
@@ -1,0 +1,100 @@
+require 'spec_helper'
+
+describe 'Product Translations', type: :feature, js: true do
+  stub_authorization!
+
+  let(:store) { Spree::Store.default }
+  let(:product) { create(:product, stores: [store]) }
+
+  context 'managing translations' do
+    context 'when there is more than one locale configured for a store' do
+      before do
+        store.update!(default_locale: 'en', supported_locales: 'en,fr')
+      end
+
+      context 'when there are no translations for a given language' do
+        let(:new_translation) { 'This is a test French translation' }
+        let(:expected_new_slug) { 'this-is-a-test-french-translation' }
+
+        it 'allows an admin to add new name translations and generates slug' do
+          visit spree.admin_product_path(product)
+
+          click_link 'Translations'
+          fill_in 'translation_name_fr', with: new_translation
+          click_button 'Update'
+
+          wait_for_turbo
+
+          expect(product.translations.count).to eq(2)
+
+          translation_fr = product.translations.find_by!(locale: 'fr')
+          expect(translation_fr.name).to eq(new_translation)
+          expect(translation_fr.slug).to eq(expected_new_slug)
+        end
+      end
+
+      context 'when there are existing translations for a given language' do
+        let(:old_name_translation) { 'Old translation' }
+        let(:old_slug_translation) { 'old-slug' }
+        let(:new_name_translation) { 'New translation' }
+        let(:new_slug_translation) { 'new-slug' }
+
+        before do
+          product.translations.create!(locale: 'fr', name: old_name_translation, slug: old_slug_translation)
+        end
+
+        it 'allows an admin to update existing name translations without updating slug' do
+          visit spree.admin_product_path(product)
+
+          click_link 'Translations'
+          expect(page).to have_field('translation_name_fr', with: old_name_translation)
+          expect(page).to have_field('translation_slug_fr', with: old_slug_translation)
+
+          fill_in 'translation_name_fr', with: new_name_translation
+          click_button 'Update'
+
+          wait_for_turbo
+
+          expect(product.translations.count).to eq(2)
+
+          translation_fr = product.translations.find_by!(locale: 'fr')
+          expect(translation_fr.name).to eq(new_name_translation)
+          expect(translation_fr.slug).to eq(old_slug_translation)
+        end
+
+        it 'allows an admin to update slug for a translation' do
+          visit spree.admin_product_path(product)
+
+          click_link 'Translations'
+          expect(page).to have_field('translation_name_fr', with: old_name_translation)
+          expect(page).to have_field('translation_slug_fr', with: old_slug_translation)
+
+          fill_in 'translation_name_fr', with: new_name_translation
+          fill_in 'translation_slug_fr', with: new_slug_translation
+          click_button 'Update'
+
+          wait_for_turbo
+
+          expect(product.translations.count).to eq(2)
+
+          translation_fr = product.translations.find_by!(locale: 'fr')
+          expect(translation_fr.name).to eq(new_name_translation)
+          expect(translation_fr.slug).to eq(new_slug_translation)
+        end
+      end
+    end
+
+    context 'when there is only a single locale configured for a store' do
+      before do
+        store.update!(default_locale: 'en', supported_locales: 'en')
+      end
+
+      it "displays a message that translations aren't configured for the store" do
+        visit spree.admin_product_path(product)
+
+        click_link 'Translations'
+        expect(page).to have_content("To use translations, configure more than one locale for the store.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR contains a fix that ensures that we always generate a slug correctly (triggering @object.save while inside I18n.with_locale).

I've also added some specs that edit the translations via the admin panel UI.