### PR TITLE
Optimize performance of loading translations

### DIFF
--- a/app/controllers/concerns/spree/admin/product_concern.rb
+++ b/app/controllers/concerns/spree/admin/product_concern.rb
@@ -4,7 +4,7 @@ module Spree
       extend ActiveSupport::Concern
 
       def product_scope
-        current_store.products.accessible_by(current_ability, :index)
+        current_store.products.accessible_by(current_ability, :index).includes(:translations)
       end
     end
   end

--- a/app/controllers/spree/admin/base_controller.rb
+++ b/app/controllers/spree/admin/base_controller.rb
@@ -70,7 +70,7 @@ module Spree
       end
 
       def stores_scope
-        Spree::Store.accessible_by(current_ability, :show)
+        Spree::Store.accessible_by(current_ability, :show).includes(:translations)
       end
 
       def load_stores


### PR DESCRIPTION
By introducing Mobility, we moved the translations to a separate table. If we don't preload translations explicitly, displaying them on the UI will trigger n + 1 queries in places where we display a list of translatable records.

I started profiling the admin panel and optimizing performance in some places that I think make sense:
- Stores - this is a list that renders in the navbar, in every view in the admin panel. For setups with a larger amount of stores, the performance issue will be issue on every single page
- Products - the list of products already triggers some n+1 queries, which should be optimized. Displaying product name in the product list had a visible impact on the performance.

I was also trying to add a similar optimization in the `TaxonomiesController#edit` (displays a tree of taxons), but it didn't work as expected. I will take another look at it separately.