### PR TITLE
Add admin panel for managing data feeds

### DIFF
--- a/app/controllers/spree/admin/data_feeds_controller.rb
+++ b/app/controllers/spree/admin/data_feeds_controller.rb
@@ -1,0 +1,12 @@
+module Spree
+  module Admin
+    class DataFeedsController < ResourceController
+      def collection
+        return @collection if @collection.present?
+
+        @collection = super
+        @collection.page(params[:page]).per(params[:per_page])
+      end
+    end
+  end
+end

--- a/app/views/spree/admin/data_feeds/_form.html.erb
+++ b/app/views/spree/admin/data_feeds/_form.html.erb
@@ -1,0 +1,29 @@
+<div data-hook="admin_webhooks_subscriber_form_fields">
+  <%= f.field_container :name, class: ['form-group'] do %>
+    <%= f.label :name %>
+    <%= f.text_field :name, class: 'form-control' %>
+    <%= f.error_message_on :name %>
+  <% end %>
+
+  <%= f.field_container :slug, class: ['form-group'] do %>
+    <%= f.label :slug, Spree.t('admin.data_feeds.slug_label') %>
+    <%= f.text_field :slug, class: 'form-control' %>
+    <%= f.error_message_on :slug %>
+  <% end %>
+
+  <%= f.field_container :provider, class: ['form-group'] do %>
+    <%= f.label :type, Spree.t('admin.data_feeds.type') %>
+    <%= f.collection_select :type, Spree::DataFeed.available_types, :name, :label, {}, class: 'form-control' %>
+    <%= f.error_message_on :type %>
+  <% end %>
+
+  <%= f.hidden_field :store_id, value: current_store.id %>
+
+  <div class="form-group">
+    <div class="custom-control custom-switch">
+      <%= f.check_box :active, class: 'custom-control-input' %>
+      <%= f.label :active, class: 'custom-control-label' %>
+    </div>
+  </div>
+
+</div>

--- a/app/views/spree/admin/data_feeds/edit.html.erb
+++ b/app/views/spree/admin/data_feeds/edit.html.erb
@@ -1,0 +1,13 @@
+<% content_for :page_title do %>
+  <%= link_to Spree.t('spree.admin.data_feeds.data_feeds'), spree.admin_data_feeds_path %> /
+  <%= @data_feed.name %>
+<% end %>
+
+<%= render partial: 'spree/admin/shared/error_messages', locals: { target: @data_feed } %>
+
+<%= form_for @data_feed, as: :data_feed, url: admin_data_feed_path(@data_feed) do |f| %>
+  <fieldset>
+    <%= render partial: 'form', locals: { f: f } %>
+    <%= render partial: 'spree/admin/shared/edit_resource_links' %>
+  </fieldset>
+<% end %>

--- a/app/views/spree/admin/data_feeds/index.html.erb
+++ b/app/views/spree/admin/data_feeds/index.html.erb
@@ -1,0 +1,45 @@
+<% content_for :page_title do %>
+  <%= Spree.t('admin.data_feeds.data_feeds') %>
+<% end %>
+
+<% content_for :page_actions do %>
+  <%= button_link_to Spree.t('admin.data_feeds.new_data_feed'), new_object_url, class: "btn-success", icon: 'add.svg', id: 'admin_new_data_feed_link' %>
+<% end if can?(:create, Spree::DataFeed) %>
+
+<% if @data_feeds.present? %>
+  <div class="table-responsive border rounded bg-white">
+    <table class="table">
+      <thead class="text-muted">
+      <tr>
+        <th><%= Spree.t('admin.name') %></th>
+        <th><%= Spree.t('admin.url') %></th>
+        <th><%= Spree.t('admin.data_feeds.type') %></th>
+        <th><%= Spree.t('admin.active') %></th>
+        <th></th>
+      </tr>
+      </thead>
+      <tbody>
+      <% @data_feeds.each do |data_feed| %>
+        <tr id="<%= spree_dom_id data_feed %>">
+          <td><%= data_feed.name %></td>
+          <td><code><%= data_feed.formatted_url %></code></td>
+          <td><%= data_feed.class.label %></td>
+          <td><%= active_badge(data_feed.active) %></td>
+          <td class="actions">
+          <span class="d-flex justify-content-end">
+            <%= link_to_edit(data_feed, no_text: true) if can? :edit, data_feed %>
+            <%= link_to_delete(data_feed, no_text: true) if can? :delete, data_feed %>
+          </span>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+  <%= render 'spree/admin/shared/index_table_options', collection: @data_feeds, simple: true %>
+<% else %>
+  <div class="text-center no-objects-found m-5">
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::DataFeed)) %>,
+    <%= link_to(Spree.t(:add_one), new_object_url) if can? :create, Spree::DataFeed %>!
+  </div>
+<% end %>

--- a/app/views/spree/admin/data_feeds/new.html.erb
+++ b/app/views/spree/admin/data_feeds/new.html.erb
@@ -1,0 +1,13 @@
+<% content_for :page_title do %>
+  <%= link_to Spree.t('spree.admin.data_feeds.data_feeds'), spree.admin_data_feeds_path %> /
+  <%= Spree.t('spree.admin.data_feeds.new_data_feed') %>
+<% end %>
+
+<%= render partial: 'spree/admin/shared/error_messages', locals: { target: @data_feed } %>
+
+<%= form_for [:admin, @data_feed] do |f| %>
+  <fieldset>
+    <%= render partial: 'form', locals: { f: f } %>
+    <%= render partial: 'spree/admin/shared/new_resource_links' %>
+  </fieldset>
+<% end %>

--- a/app/views/spree/admin/shared/sub_menu/_integrations.html.erb
+++ b/app/views/spree/admin/shared/sub_menu/_integrations.html.erb
@@ -1,4 +1,5 @@
 <ul id="sidebar-integrations" class="collapse nav nav-pills nav-stacked pb-2" data-hook="admin_integrations">
   <%= tab :payment_methods, match_path: '/payment_methods', label: 'Payment Methods' if can? :manage, Spree::PaymentMethod %>
+  <%= tab :data_feeds, match_path: '/data_feeds', label: 'Data Feeds' if can? :manage, Spree::DataFeed %>
   <%= tab :webhooks_subscribers, match_path: '/webhooks_subscribers', label: 'Webhooks' if can? :manage, Spree::Webhooks::Subscriber %>
 </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,6 +80,11 @@ en:
           square_image: Please use an image with an aspect ratio of 18:13 (1080px x 780px).
           tall_image: Please use an image with an aspect ratio of 27:40 (1080px x 1600px).
       copy_to_clipboard: Copy to clipboard
+      data_feeds:
+        data_feeds: Data Feeds
+        type: Type
+        slug_label: Slug (leave blank to generate)
+        new_data_feed: New Data Feed
       digitals:
         digital: Digital
         add_new_file: Add a new digital asset.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -215,6 +215,8 @@ Spree::Core::Engine.add_routes do
       end
     end
 
+    resources :data_feeds
+
     resources :webhooks_subscribers
 
     get '/forbidden', to: 'errors#forbidden', as: :forbidden


### PR DESCRIPTION
This PR relies on https://github.com/spree/spree/pull/11877

In this PR, I've added a separate admin page for managing data feeds (available via "Integrations" menu on the left hand side). 

<img width="1552" alt="Screenshot 2023-04-15 at 9 25 33 PM" src="https://user-images.githubusercontent.com/6420475/232249622-6662f8bc-54ab-4e6c-b56f-b722a736a69e.png">
<img width="1552" alt="Screenshot 2023-04-15 at 9 25 41 PM" src="https://user-images.githubusercontent.com/6420475/232249633-4966669b-50d8-493a-a641-e61e5edb0440.png">

TBD: Make selecting a provider more intuitive