### PR TITLE
Add default locale notice

### DIFF
--- a/app/views/spree/admin/stores/form/_internationalization.html.erb
+++ b/app/views/spree/admin/stores/form/_internationalization.html.erb
@@ -40,6 +40,9 @@
       <%= f.label :default_locale %>
       <%= f.select :default_locale, options_from_collection_for_select(all_locales_options, :last, :first, @store.default_locale || I18n.locale), {}, { class: 'select2' } %>
       <%= f.error_message_on :default_locale %>
+      <small class="form-text text-muted">
+        <%= Spree.t('admin.store_form.default_locale_notice') %>
+      </small>
       <% unless defined?(SpreeI18n) %>
         <small class="form-text text-muted">
           <%= raw(Spree.t('admin.store_form.locales_help')) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -173,6 +173,7 @@ en:
           For more information <a href='https://guides.spreecommerce.org/user/configuration/configuring_geography.html#zones' target='_blank' class='alert-link'>please see documentation</a>"
         currencies_help: "You can accept payments in multiple currencies. Each product and product variant can have different price in different currency"
         locales_help: "Install <a href='https://github.com/spree-contrib/spree_i18n' target='_blank' class='alert-link'>Spree I18n extension</a> to add more locales"
+        default_locale_notice: "Warning: Before changing the default locale, ensure that all products, taxons and stores have translations in the new locale"
         social_help: "If you want to link to your social accounts in the footer part of your website please fill below fields"
         default_country_help: "This is the Country that will be pre-selected on the Checkout Address form"
         footer_help: "This content is visible in the footer section of your Store"


### PR DESCRIPTION
Store's default locale is used as a fallback when fetching permalinks, names etc. 
When the default locale is changed by the admin, and some entities don't have translation records in the new default locale, we may encounter a weird behavior e.g. not being able to edit the product in the admin panel.

This PR adds a notice under the default locale selector in the store settings.
I believe we should look at a better UX for this, ideally an alert that would ideally check if all the entities are correctly translated. I will prepare a PoC of that in the upcoming PRs.