### PR TITLE
Remove "or import from CSV" from the label in the admin panel - SP-72

### DIFF
--- a/app/views/spree/admin/dashboard/_getting_started.html.erb
+++ b/app/views/spree/admin/dashboard/_getting_started.html.erb
@@ -44,7 +44,8 @@
           <p><%= Spree.t('admin.gettting_started.products_section.message_with_products_html', count: current_store.products.count ) %></p>
         <% else %>
           <p>
-            <%= Spree.t('admin.gettting_started.products_section.message_without_products', link: link_to(Spree.t('admin.gettting_started.products_section.import_message'), 'https://api.spreecommerce.org/docs/api-v2/27527143a4edf-create-a-product')).html_safe %>
+            <%= Spree.t('admin.gettting_started.products_section.message_without_products') %>
+            <%= link_to(Spree.t('admin.gettting_started.products_section.import_message'), 'https://api.spreecommerce.org/docs/api-v2/27527143a4edf-create-a-product') %>
           </p>
           <%= link_to_with_icon 'add.svg', Spree.t('admin.gettting_started.add_products'), spree.admin_products_path, class: 'btn btn-success btn-sm mb-2' %>
         <% end %>

--- a/app/views/spree/admin/dashboard/_getting_started.html.erb
+++ b/app/views/spree/admin/dashboard/_getting_started.html.erb
@@ -44,7 +44,7 @@
           <p><%= Spree.t('admin.gettting_started.products_section.message_with_products_html', count: current_store.products.count ) %></p>
         <% else %>
           <p>
-            <%= Spree.t('admin.gettting_started.products_section.message_without_products') %>
+            <%= Spree.t('admin.gettting_started.products_section.message_without_products', link: link_to(Spree.t('admin.gettting_started.products_section.import_message'), 'https://api.spreecommerce.org/docs/api-v2/27527143a4edf-create-a-product')).html_safe %>
           </p>
           <%= link_to_with_icon 'add.svg', Spree.t('admin.gettting_started.add_products'), spree.admin_products_path, class: 'btn btn-success btn-sm mb-2' %>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -326,7 +326,8 @@ en:
         setup_taxes_calculation: Setup tax calculation
         products_section:
           message_with_products_html: You have added <strong> %{count} products</strong> so far - good job!</p>
-          message_without_products: You can add products manually through API or import from a CSV file.
+          message_without_products: You can add products manually or %{link}
+          import_message: import them via the API.
         shipping_section:
           message_with_shipping: You have setup shipping for
           message_without_shipping: You can add multiple shipping methods, different for each country, continent or region.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -326,7 +326,7 @@ en:
         setup_taxes_calculation: Setup tax calculation
         products_section:
           message_with_products_html: You have added <strong> %{count} products</strong> so far - good job!</p>
-          message_without_products: You can add products manually or %{link}
+          message_without_products: You can add products manually or
           import_message: import them via the API.
         shipping_section:
           message_with_shipping: You have setup shipping for


### PR DESCRIPTION
Changed the message from "add products manually through the API or import from a CSV file" to "You can add products manually or import them via the API" with a link to the documentation. This branch should be also merged to 4-6-stable and 4-5-stable. It also has some Spanish translations in spree_i18n, so it's worth updating it together.