### PR TITLE
Link to documentation added in Oauth applications list in admin panel SP-68

### DIFF
--- a/app/controllers/spree/admin/oauth_applications_controller.rb
+++ b/app/controllers/spree/admin/oauth_applications_controller.rb
@@ -3,6 +3,10 @@ module Spree
     class OauthApplicationsController < ResourceController
       before_action :set_default_scopes, only: [:new, :edit]
 
+      def index
+        flash.now[:notice] = Spree.t('admin.oauth_applications.documentation_message').html_safe
+      end
+
       private
 
       def create_turbo_stream_enabled?

--- a/app/controllers/spree/admin/oauth_applications_controller.rb
+++ b/app/controllers/spree/admin/oauth_applications_controller.rb
@@ -3,10 +3,6 @@ module Spree
     class OauthApplicationsController < ResourceController
       before_action :set_default_scopes, only: [:new, :edit]
 
-      def index
-        flash.now[:notice] = Spree.t('admin.oauth_applications.documentation_message').html_safe
-      end
-
       private
 
       def create_turbo_stream_enabled?

--- a/app/views/spree/admin/oauth_applications/index.html.erb
+++ b/app/views/spree/admin/oauth_applications/index.html.erb
@@ -9,8 +9,9 @@
 <div class="container">
   <div class="card">
     <div class="card-body">
-      <p><%=Spree.t('admin.oauth_applications.documentation_message')%>
-      <%= link_to('here.', 'https://dev-docs.spreecommerce.org/api/platform-api/authenticating-requests')%>
+      <p>
+        <%=Spree.t('admin.oauth_applications.documentation_message')%>
+        <%= link_to(Spree.t('admin.oauth_applications.here'), 'https://dev-docs.spreecommerce.org/api/platform-api/authenticating-requests')%>
       </p>
     </div>
   </div>

--- a/app/views/spree/admin/oauth_applications/index.html.erb
+++ b/app/views/spree/admin/oauth_applications/index.html.erb
@@ -6,6 +6,16 @@
   <%= button_link_to Spree.t('admin.oauth_applications.new'), new_object_url, class: "btn-success", icon: 'add.svg', id: 'admin_new_role_link' %>
 <% end if can? :create, Spree::OauthApplication %>
 
+<div class="container">
+  <div class="card">
+    <div class="card-body">
+      <p><%=Spree.t('admin.oauth_applications.documentation_message')%>
+      <%= link_to('here.', 'https://dev-docs.spreecommerce.org/api/platform-api/authenticating-requests')%>
+      </p>
+    </div>
+  </div>
+</div>
+
 <% if @oauth_applications.any? %>
   <div class="table-responsive rounded border mt-4">
     <table class="table">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -169,7 +169,7 @@ en:
         new: New oAuth application
         uid: UID
         scopes: Scopes
-        documentation_message: 'If you need help, you can find documentation&nbsp<a href="https://dev-docs.spreecommerce.org/api/platform-api/authenticating-requests">here</a>.'
+        documentation_message: 'If you need help, you can find documentation '
       reports:
         for: For %{store_name}
       return_authorization:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -169,6 +169,7 @@ en:
         new: New oAuth application
         uid: UID
         scopes: Scopes
+        documentation_message: 'If you need help, you can find documentation&nbsp<a href="https://dev-docs.spreecommerce.org/api/platform-api/authenticating-requests">here</a>.'
       reports:
         for: For %{store_name}
       return_authorization:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -170,6 +170,7 @@ en:
         uid: UID
         scopes: Scopes
         documentation_message: 'If you need help, you can find documentation '
+        here: here.
       reports:
         for: For %{store_name}
       return_authorization:


### PR DESCRIPTION
Notice with link to documentation added. Not sure if using flash notice is the best way to do it, so please review it. Also, the message can be updated. I'm attaching a photo to show you how it looks like for now. 

<img width="1440" alt="Documentation link" src="https://github.com/spree/spree_backend/assets/62781565/b002abd7-5c4a-48e0-bbdc-4744bed81530">
