### PR TITLE
chore: Update rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -181,7 +181,10 @@ RSpec/NamedSubject:
 RSpec/MultipleExpectations:
   Enabled: false
 
-RSpec/FilePath:
+RSpec/SpecFilePathFormat:
+  Enabled: false
+
+RSpec/SpecFilePathSuffix:
   Enabled: false
 
 RSpec/LetSetup:


### PR DESCRIPTION
### **What?**
Currently used cop `RSpec/FilePath`was deprecated, and was split into two separate cops (`RSpec/SpecFilePathFormat` and `RSpec/SpecFilePathSuffix`).
[docs](https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FilePath)

### **Why?**
Rubocop didn't start locally.

### **How?**
Use new cops.