### PR TITLE
Fix layout depending on rails_5? helper

### DIFF
--- a/app/views/spree/admin/cms_sections/types/_image_gallery.html.erb
+++ b/app/views/spree/admin/cms_sections/types/_image_gallery.html.erb
@@ -37,17 +37,15 @@
       <% end %>
 
       <div class="col-12"><hr></div>
-      <% unless rails_5? %>
-        <%= f.field_container :link_type_one do %>
-          <%= f.label :link_type_one, Spree.t('admin.navigation.link_to') %>
-          <%= f.select(:link_type_one,
-              spree_humanize_dropdown_values('Spree::Cms::Sections::ImageGallery',
-                                              { const: 'LINKED_RESOURCE_TYPE' }),
-                                              { include_blank: false },
-                                              class: 'link_switcher',
-                                              data: { target_field: :link_one}) %>
-          <%= f.error_message_on :link_type_one %>
-        <% end %>
+      <%= f.field_container :link_type_one do %>
+        <%= f.label :link_type_one, Spree.t('admin.navigation.link_to') %>
+        <%= f.select(:link_type_one,
+            spree_humanize_dropdown_values('Spree::Cms::Sections::ImageGallery',
+                                            { const: 'LINKED_RESOURCE_TYPE' }),
+                                            { include_blank: false },
+                                            class: 'link_switcher',
+                                            data: { target_field: :link_one}) %>
+        <%= f.error_message_on :link_type_one %>
       <% end %>
       <%= render "spree/admin/shared/link_fields", resource: @cms_section, linked_type: @cms_section.link_type_one, save_to: :link_one, f: f %>
     </div>
@@ -69,17 +67,15 @@
       <% end %>
 
       <div class="col-12"><hr></div>
-      <% unless rails_5? %>
-        <%= f.field_container :link_type_two do %>
-          <%= f.label :link_type_two, Spree.t('admin.navigation.link_to') %>
-          <%= f.select(:link_type_two,
-              spree_humanize_dropdown_values('Spree::Cms::Sections::ImageGallery',
-                                              { const: 'LINKED_RESOURCE_TYPE' }),
-                                              { include_blank: false },
-                                              class: 'link_switcher',
-                                              data: { target_field: :link_two}) %>
-          <%= f.error_message_on :link_type_two %>
-        <% end %>
+      <%= f.field_container :link_type_two do %>
+        <%= f.label :link_type_two, Spree.t('admin.navigation.link_to') %>
+        <%= f.select(:link_type_two,
+            spree_humanize_dropdown_values('Spree::Cms::Sections::ImageGallery',
+                                            { const: 'LINKED_RESOURCE_TYPE' }),
+                                            { include_blank: false },
+                                            class: 'link_switcher',
+                                            data: { target_field: :link_two}) %>
+        <%= f.error_message_on :link_type_two %>
       <% end %>
       <%= render "spree/admin/shared/link_fields", resource: @cms_section, linked_type: @cms_section.link_type_two, save_to: :link_two, f: f %>
     </div>
@@ -101,17 +97,15 @@
       <% end %>
 
       <div class="col-12"><hr></div>
-      <% unless rails_5? %>
-        <%= f.field_container :link_type_three do %>
-          <%= f.label :link_type_three, Spree.t('admin.navigation.link_to') %>
-          <%= f.select(:link_type_three,
-              spree_humanize_dropdown_values('Spree::Cms::Sections::ImageGallery',
-                                              { const: 'LINKED_RESOURCE_TYPE' }),
-                                              { include_blank: false },
-                                              class: 'link_switcher',
-                                              data: { target_field: :link_three}) %>
-          <%= f.error_message_on :link_type_three %>
-        <% end %>
+      <%= f.field_container :link_type_three do %>
+        <%= f.label :link_type_three, Spree.t('admin.navigation.link_to') %>
+        <%= f.select(:link_type_three,
+            spree_humanize_dropdown_values('Spree::Cms::Sections::ImageGallery',
+                                            { const: 'LINKED_RESOURCE_TYPE' }),
+                                            { include_blank: false },
+                                            class: 'link_switcher',
+                                            data: { target_field: :link_three}) %>
+        <%= f.error_message_on :link_type_three %>
       <% end %>
       <%= render "spree/admin/shared/link_fields", resource: @cms_section, linked_type: @cms_section.link_type_three, save_to: :link_three, f: f %>
     </div>

--- a/app/views/spree/admin/cms_sections/types/_side_by_side_images.html.erb
+++ b/app/views/spree/admin/cms_sections/types/_side_by_side_images.html.erb
@@ -21,17 +21,15 @@
       <% end %>
 
       <div class="col-12"><hr></div>
-      <% unless rails_5? %>
-        <%= f.field_container :link_type_one do %>
-          <%= f.label :link_type_one, Spree.t('admin.navigation.link_to') %>
-          <%= f.select(:link_type_one,
-              spree_humanize_dropdown_values('Spree::Cms::Sections::SideBySideImages',
-                                              { const: 'LINKED_RESOURCE_TYPE' }),
-                                              { include_blank: false },
-                                              class: 'link_switcher',
-                                              data: { target_field: :link_one}) %>
-          <%= f.error_message_on :link_type_one %>
-        <% end %>
+      <%= f.field_container :link_type_one do %>
+        <%= f.label :link_type_one, Spree.t('admin.navigation.link_to') %>
+        <%= f.select(:link_type_one,
+            spree_humanize_dropdown_values('Spree::Cms::Sections::SideBySideImages',
+                                            { const: 'LINKED_RESOURCE_TYPE' }),
+                                            { include_blank: false },
+                                            class: 'link_switcher',
+                                            data: { target_field: :link_one}) %>
+        <%= f.error_message_on :link_type_one %>
       <% end %>
       <%= render "spree/admin/shared/link_fields", resource: @cms_section, linked_type: @cms_section.link_type_one, save_to: :link_one, f: f %>
     </div>
@@ -60,17 +58,15 @@
 
       <div class="col-12"><hr></div>
 
-      <% unless rails_5? %>
-        <%= f.field_container :link_type_two do %>
-          <%= f.label :link_type_two, Spree.t('admin.navigation.link_to') %>
-          <%= f.select(:link_type_two,
-              spree_humanize_dropdown_values('Spree::Cms::Sections::SideBySideImages',
-                                              { const: 'LINKED_RESOURCE_TYPE' }),
-                                              { include_blank: false },
-                                              class: 'link_switcher',
-                                              data: { target_field: :link_two}) %>
-          <%= f.error_message_on :link_type_two %>
-        <% end %>
+      <%= f.field_container :link_type_two do %>
+        <%= f.label :link_type_two, Spree.t('admin.navigation.link_to') %>
+        <%= f.select(:link_type_two,
+            spree_humanize_dropdown_values('Spree::Cms::Sections::SideBySideImages',
+                                            { const: 'LINKED_RESOURCE_TYPE' }),
+                                            { include_blank: false },
+                                            class: 'link_switcher',
+                                            data: { target_field: :link_two}) %>
+        <%= f.error_message_on :link_type_two %>
       <% end %>
       <%= render "spree/admin/shared/link_fields", resource: @cms_section, linked_type: @cms_section.link_type_two, save_to: :link_two, f: f %>
     </div>


### PR DESCRIPTION
Some layouts depended on the `rails_5?` method provided by one of the helpers in Spree core. The method was removed, as we no longer support Rails 5, which broke some templates. This PR fixes that.