### PR TITLE
Update preview label

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -254,7 +254,7 @@ en:
         this_link_takes_you_to_your_stores_home_page: This link takes you to your stores home page.
       settings: Settings
       utilities:
-        preview: Preview %{name}
+        preview: Preview
       webhooks_subscribers:
         webhooks_subscribers: Webhooks Subscribers
         new_webhooks_subscriber: New Webhooks Subscriber


### PR DESCRIPTION
There's a `utilities.preview` label in the codebase, that allows to inject a custom name parameter to it. This is only used for products, and looking at how we use it, it doesn't even make that much sense to specify the target of the preview - it's obvious from the context