### PR TITLE
Add generic tabs partial

### DIFF
--- a/app/views/spree/admin/shared/_order_tabs.html.erb
+++ b/app/views/spree/admin/shared/_order_tabs.html.erb
@@ -4,15 +4,5 @@
 <% end %>
 
 <% content_for :page_tabs do %>
-  <% order_tabs.items.each do |tab| %>
-    <% next unless tab.available?(current_ability, @order) %>
-      <%= content_tag :li, class: 'nav-item', data: { hook: tab.data_hook } do %>
-        <%= link_to_with_icon(
-          tab.icon_key,
-          Spree.t(tab.label_translation_key),
-          tab.url(@order),
-          class: tab.active?(current) ? 'active nav-link' : 'nav-link'
-        ) %>
-      <% end %>
-  <% end %>
+  <%= render partial: 'spree/admin/shared/tabs', locals: { tabs: order_tabs, object: @order, current: current } %>
 <% end %>

--- a/app/views/spree/admin/shared/_product_tabs.html.erb
+++ b/app/views/spree/admin/shared/_product_tabs.html.erb
@@ -4,15 +4,5 @@
 <% end %>
 
 <% content_for :page_tabs do %>
-  <% product_tabs.items.each do |tab| %>
-    <% next unless tab.available?(current_ability, @product) %>
-      <li class="nav-item">
-        <%= link_to_with_icon(
-          tab.icon_key,
-          Spree.t(tab.label_translation_key),
-          tab.url(@product),
-          class: tab.active?(current) ? 'active nav-link' : 'nav-link'
-        ) %>
-      </li>
-  <% end %>
+  <%= render partial: 'spree/admin/shared/tabs', locals: { tabs: product_tabs, object: @product, current: current } %>
 <% end %>

--- a/app/views/spree/admin/shared/_tabs.html.erb
+++ b/app/views/spree/admin/shared/_tabs.html.erb
@@ -1,0 +1,11 @@
+<% tabs.items.each do |tab| %>
+  <% next unless tab.available?(current_ability, object) %>
+  <%= content_tag :li, class: 'nav-item', data: { hook: tab.data_hook } do %>
+    <%= link_to_with_icon(
+      tab.icon_key,
+      Spree.t(tab.label_translation_key),
+      tab.url(object),
+      class: tab.active?(current) ? 'active nav-link' : 'nav-link'
+    ) %>
+  <% end %>
+<% end %>

--- a/app/views/spree/admin/users/_tabs.html.erb
+++ b/app/views/spree/admin/users/_tabs.html.erb
@@ -4,15 +4,5 @@
 <% end %>
 
 <% content_for :page_tabs do %>
-  <% user_tabs.items.each do |tab| %>
-    <% next unless tab.available?(current_ability, @user) %>
-      <li class="nav-item">
-        <%= link_to_with_icon(
-          tab.icon_key,
-          Spree.t(tab.label_translation_key),
-          tab.url(@user),
-          class: tab.active?(current) ? 'active nav-link' : 'nav-link'
-        ) %>
-      </li>
-  <% end %>
+  <%= render partial: 'spree/admin/shared/tabs', locals: { tabs: user_tabs, object: @user, current: current } %>
 <% end %>


### PR DESCRIPTION
This PR adds a spree/admin/shared/tabs partial, which unifies the logic for rendering tabs to a single place. 
This way extensions can also render tabs for their custom entities, without much hassle.