### PR TITLE
Remove Spree::Config[:default_country_id] usages

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -92,9 +92,8 @@ RSpec.configure do |config|
     reset_spree_preferences
 
     country = create(:country, name: 'United States of America', iso_name: 'UNITED STATES', iso: 'US', states_required: true)
-    Spree::Config[:default_country_id] = country.id
 
-    create(:store, default: true)
+    create(:store, default_country: country, default: true)
   end
 
   config.after(:each, type: :feature) do |example|


### PR DESCRIPTION
Follow-up to https://github.com/spree/spree/pull/11964