### PR TITLE
Remove setting Spree::Config.default_country_id in a spec

### DIFF
--- a/spec/features/admin/orders/customer_details_spec.rb
+++ b/spec/features/admin/orders/customer_details_spec.rb
@@ -64,7 +64,6 @@ describe 'Customer Details', type: :feature, js: true do
   context 'editing an order' do
     before do
       configure_spree_preferences do |config|
-        config.default_country_id = country.id
         config.company = true
       end
 


### PR DESCRIPTION
I missed this one, and it broke only after I removed default_country_id from Spree::Core. 
Follow-up to https://github.com/spree/spree_backend/pull/288