### PR TITLE
Use runtime configuration for admin_path

### DIFF
--- a/app/views/spree/admin/shared/_version.html.erb
+++ b/app/views/spree/admin/shared/_version.html.erb
@@ -1,4 +1,4 @@
-<% if can?(:admin, current_store) && Spree::Backend::Config[:admin_show_version] %>
+<% if can?(:admin, current_store) && Spree::Backend::RuntimeConfig[:admin_show_version] %>
   <p
     class="spree-version ml-3 my-3"
     aria-label="Spree Commerce version">

--- a/lib/spree/backend/configuration.rb
+++ b/lib/spree/backend/configuration.rb
@@ -1,14 +1,12 @@
 module Spree
   module Backend
     class Configuration < Preferences::Configuration
-      preference :admin_path, :string, default: '/admin'
       preference :admin_products_per_page, :integer, default: Kaminari.config.default_per_page
       preference :admin_orders_per_page, :integer, default: Kaminari.config.default_per_page
       preference :admin_properties_per_page, :integer, default: Kaminari.config.default_per_page
       preference :admin_promotions_per_page, :integer, default: Kaminari.config.default_per_page
       preference :admin_customer_returns_per_page, :integer, default: Kaminari.config.default_per_page
       preference :admin_users_per_page, :integer, default: Kaminari.config.default_per_page
-      preference :admin_show_version, :boolean, default: true
       preference :locale, :string
       preference :variants_per_page, :integer, default: Kaminari.config.default_per_page
       preference :menus_per_page, :integer, default: Kaminari.config.default_per_page

--- a/lib/spree/backend/engine.rb
+++ b/lib/spree/backend/engine.rb
@@ -1,4 +1,5 @@
 require_relative 'configuration'
+require_relative 'runtime_configuration'
 
 module Spree
   module Backend
@@ -9,6 +10,7 @@ module Spree
 
       initializer 'spree.backend.environment', before: :load_config_initializers do |app|
         Spree::Backend::Config = Spree::Backend::Configuration.new
+        Spree::Backend::RuntimeConfig = Spree::Backend::RuntimeConfiguration.new
         app.config.spree_backend = Environment.new
       end
 

--- a/lib/spree/backend/runtime_configuration.rb
+++ b/lib/spree/backend/runtime_configuration.rb
@@ -1,0 +1,8 @@
+module Spree
+  module Backend
+    class RuntimeConfiguration < ::Spree::Preferences::RuntimeConfiguration
+      preference :admin_path, :string, default: '/admin'
+      preference :admin_show_version, :boolean, default: true
+    end
+  end
+end

--- a/lib/spree_backend.rb
+++ b/lib/spree_backend.rb
@@ -2,7 +2,7 @@ require 'spree/backend'
 
 module Spree
   def self.admin_path
-    Spree::Backend::Config[:admin_path]
+    Spree::Backend::RuntimeConfig[:admin_path]
   end
 
   # Used to configure admin_path for Spree
@@ -13,6 +13,6 @@ module Spree
   #   Spree.admin_path = '/custom-path'
 
   def self.admin_path=(path)
-    Spree::Backend::Config[:admin_path] = path
+    Spree::Backend::RuntimeConfig[:admin_path] = path
   end
 end

--- a/spec/features/admin/homepage_spec.rb
+++ b/spec/features/admin/homepage_spec.rb
@@ -39,7 +39,7 @@ describe 'Homepage', type: :feature do
         end
 
         context 'if turned off' do
-          before { Spree::Backend::Config[:admin_show_version] = false }
+          before { Spree::Backend::RuntimeConfig[:admin_show_version] = false }
 
           it 'is not displayed' do
             visit spree.admin_path

--- a/spec/lib/spree/core_spec.rb
+++ b/spec/lib/spree/core_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Spree do
   describe '.admin_path' do
-    it { expect(described_class.admin_path).to eq(Spree::Backend::Config[:admin_path]) }
+    it { expect(described_class.admin_path).to eq(Spree::Backend::RuntimeConfig[:admin_path]) }
   end
 
   describe '.admin_path=' do
@@ -18,6 +18,6 @@ describe Spree do
     end
 
     it { expect(described_class.admin_path).to eq(new_admin_path) }
-    it { expect(Spree::Backend::Config[:admin_path]).to eq(new_admin_path) }
+    it { expect(Spree::Backend::RuntimeConfig[:admin_path]).to eq(new_admin_path) }
   end
 end


### PR DESCRIPTION
Some preferences like `admin_path` cannot be changed dynamically in a running application, therefore it doesn't make sense to persist them in the database. 
This PR follows-up on https://github.com/spree/spree/pull/11965/files , which introduced a `RuntimeConfiguration` class, and moves `admin_path` (that's used when defining routes upon application boot) and `admin_show_version` (which I think doesn't really make sense to be dynamically configurable, but I'm open to discuss that).