### PR TITLE
Display webhook secret key in admin panel

### DIFF
--- a/app/views/spree/admin/webhooks_subscribers/index.html.erb
+++ b/app/views/spree/admin/webhooks_subscribers/index.html.erb
@@ -15,6 +15,7 @@
         <% if defined?(Spree::Vendor) && can?(:manage, Spree::Vendor) && !current_spree_vendor %>
           <th><%= Spree.t(:vendor) %></th>
         <% end %>
+        <th><%= Spree.t('admin.webhooks_subscribers.secret_key') %></th>
         <th><%= Spree.t('admin.active') %></th>
         <th><%= Spree.t('admin.webhooks_subscribers.subscriptions') %></th>
         <th><%= Spree.t('admin.webhooks_subscribers.time_of_last_event') %></th>
@@ -31,6 +32,16 @@
               <%= link_to webhooks_subscriber.vendor.name, spree.admin_vendor_path(webhooks_subscriber.vendor) if webhooks_subscriber.vendor.present? %>
             </td>
           <% end %>
+          <td>
+          <div class="input-group" data-controller="password-toggle">
+            <%= password_field_tag :password, webhooks_subscriber.secret_key, class: 'form-control unhide text-muted border-0 shadow-none bg-transparent', data: { password_toggle_target: 'unhide' }, readonly: true %>
+            <div class="input-group-append">
+              <%= button_tag class: 'btn btn-link rounded', data: { action: 'click->password-toggle#password' } do %>
+                <%= svg_icon name: "view.svg", width: '18', height: '18' %>
+              <% end %>
+            </div>
+          </div>
+        </td>
           <td><%= active_badge(webhooks_subscriber.active) %></td>
           <td><%= webhooks_subscriber.subscriptions&.sort&.join(', ') %></td>
           <td><%= webhooks_subscriber.events.order(:created_at).last&.created_at %></td>


### PR DESCRIPTION
The Webhook secret keys are displayed alongside different data in admin panel.

![Screenshot 2023-12-08 at 12 57 28](https://github.com/spree/spree_backend/assets/26871147/3327d222-0beb-45fb-8893-552dad0b5964)

Secret keys are hidden until the user toggles their visibility. The UI and the logic of the toggle button is the same as [here](https://spree-staging-4-7.upsidelab.net/admin/oauth_applications).
