### PR TITLE
Allow PaymentMethod to register a custom partial view to display above "Payment Provider Settings"

### DIFF
--- a/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/app/views/spree/admin/payment_methods/_form.html.erb
@@ -58,6 +58,18 @@
 
     <% unless @object.new_record? %>
     <div class="col-12 col-md-6">
+
+    <% if @object.respond_to?(:payment_configuration_guide) %>
+      <div class="card mb-3">
+        <div class="card-header">
+          <h5 class="mb-0"><%= Spree.t(:payment_method_configuration) %></h5>
+        </div>
+        <div class="card-body">
+        <%= render "spree/admin/payment_methods/configuration_guides/#{@object.payment_configuration_guide}" %>
+        </div>
+    </div>
+    <% end %>
+
       <div class="card mb-3">
         <div class="card-header">
           <h5 class="mb-0"><%= Spree.t(:payment_provider_settings) %></h5>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -339,3 +339,6 @@ en:
         taxes_section:
           message_with_taxes: You're tax calculation is setup!
           message_without_taxes: You can use tax services such as TaxJar or setup tax calculation manually
+      payment_methods:
+        edit:
+          payment_method_configuration: "Payment Method Configuration"


### PR DESCRIPTION
Allows user to define a custom partial view containing instructions for Payment Method configuration. 

## The process of creating a custom partial:

1. Create partial view file in `/spree_backend/app/views/spree/admin/payment_methods/configuration_guides/`- create the `configuration_guides` folder if it doesn't exist.
2. The name of the file has to follow the formula: `_name.html.erb`.
3. Define a method `payment_configuration_guide` in chosen Payment Method class declaration. It should return the name of partial file.

## Example custom partial view configuration for Spree::Gateway::Bogus:

### View of the Payment Methods edit page before the changes:
![Screenshot 2023-12-11 at 12 10 13](https://github.com/spree/spree_backend/assets/26871147/b93887eb-003e-44f6-b2aa-64251328c351)

1. Create partial `_bogus_partial.html.erb` in said directory. Contents of example partial file:
```
hi, I'm working!
```
2. Find the Spree::Gateway::Bogus class declaration. For this example the path is: `/spree/core/app/models/spree/gateway/bogus.rb`. Add following method to class declaration:
```ruby
def payment_configuration_guide
    "bogus_partial"
end
```

### View of the Payment Methods edit page after the changes:

![Screenshot 2023-12-11 at 12 16 01](https://github.com/spree/spree_backend/assets/26871147/b6db23be-a3ef-4773-a80b-39203117982b)

