### PR TITLE
Fix an issue with missing variants when adding a new product with a prototype

### DIFF
--- a/app/controllers/spree/admin/products_controller.rb
+++ b/app/controllers/spree/admin/products_controller.rb
@@ -10,7 +10,6 @@ module Spree
       before_action :set_product_defaults, only: :new
 
       create.before :create_before
-      create.before :save_option_values
       update.before :update_before
       update.before :skip_updating_status
       update.after :update_status
@@ -166,11 +165,6 @@ module Spree
         return if params[:product][:prototype_id].blank?
 
         @prototype = Spree::Prototype.find(params[:product][:prototype_id])
-      end
-
-      def save_option_values
-        option_values_hash = params[:option_values_hash]
-        params[:product][:option_values_hash] = option_values_hash if option_values_hash.present?
       end
 
       def update_before

--- a/app/views/spree/admin/prototypes/show.html.erb
+++ b/app/views/spree/admin/prototypes/show.html.erb
@@ -13,7 +13,7 @@
             <% ot.option_values.each do |ov| %>
               <li>
                 <%= label_tag "option_value_#{ov.id}" do %>
-                  <%= check_box_tag "product[option_values_hash[#{ot.id}]][]", ov.id, params[:product] && (params[:product][:option_values_hash] || {}).values.flatten.include?(ov.id.to_s), id: "option_value_#{ov.id}", class: "option-value" %>
+                  <%= check_box_tag "option_values_hash[#{ot.id}][]", ov.id, params[:product] && (params[:product][:option_values_hash] || {}).values.flatten.include?(ov.id.to_s), id: "option_value_#{ov.id}", class: "option-value" %>
                   <div class="option-value__color" style="--presentation: <%= ov.presentation %>"></div>
                 <% end %>
               </li>
@@ -23,7 +23,7 @@
           <ul class="option-type-values">
             <% ot.option_values.each do |ov| %>
               <li>
-                <%= check_box_tag "product[option_values_hash[#{ot.id}]][]", ov.id, params[:product] && (params[:product][:option_values_hash] || {}).values.flatten.include?(ov.id.to_s), id: "option_value_#{ov.id}", class: "option-value" %>
+                <%= check_box_tag "option_values_hash[#{ot.id}][]", ov.id, params[:product] && (params[:product][:option_values_hash] || {}).values.flatten.include?(ov.id.to_s), id: "option_value_#{ov.id}", class: "option-value" %>
                 <%= label_tag "option_value_#{ov.id}", ov.presentation %>
               </li>
             <% end %>

--- a/app/views/spree/admin/prototypes/show.html.erb
+++ b/app/views/spree/admin/prototypes/show.html.erb
@@ -13,7 +13,7 @@
             <% ot.option_values.each do |ov| %>
               <li>
                 <%= label_tag "option_value_#{ov.id}" do %>
-                  <%= check_box_tag "option_values_hash[#{ot.id}][]", ov.id, params[:product] && (params[:product][:option_values_hash] || {}).values.flatten.include?(ov.id.to_s), id: "option_value_#{ov.id}", class: "option-value" %>
+                  <%= check_box_tag "product[option_values_hash][#{ot.id}][]", ov.id, params[:product] && (params[:product][:option_values_hash] || {}).values.flatten.include?(ov.id.to_s), id: "option_value_#{ov.id}", class: "option-value" %>
                   <div class="option-value__color" style="--presentation: <%= ov.presentation %>"></div>
                 <% end %>
               </li>
@@ -23,7 +23,7 @@
           <ul class="option-type-values">
             <% ot.option_values.each do |ov| %>
               <li>
-                <%= check_box_tag "option_values_hash[#{ot.id}][]", ov.id, params[:product] && (params[:product][:option_values_hash] || {}).values.flatten.include?(ov.id.to_s), id: "option_value_#{ov.id}", class: "option-value" %>
+                <%= check_box_tag "product[option_values_hash][#{ot.id}][]", ov.id, params[:product] && (params[:product][:option_values_hash] || {}).values.flatten.include?(ov.id.to_s), id: "option_value_#{ov.id}", class: "option-value" %>
                 <%= label_tag "option_value_#{ov.id}", ov.presentation %>
               </li>
             <% end %>

--- a/spec/features/admin/products/products_spec.rb
+++ b/spec/features/admin/products/products_spec.rb
@@ -222,7 +222,8 @@ describe 'Products', type: :feature do
 
       let(:prototype) do
         size = build_option_type_with_values('size', %w(Small Medium Large))
-        FactoryBot.create(:prototype, name: 'Size', option_types: [size])
+        length = build_option_type_with_values('length', %w(Short, Long))
+        FactoryBot.create(:prototype, name: 'Size', option_types: [size, length])
       end
 
       let(:option_values_hash) do
@@ -252,14 +253,18 @@ describe 'Products', type: :feature do
         fill_in 'product_price', with: '100'
 
         find('[name="product[prototype_id]"]').find(:option, 'Size').select_option
+        check 'Small'
+        check 'Medium'
         check 'Large'
+        check 'Short'
+        check 'Long'
         find('[name="product[shipping_category_id]"]').find(:option, @shipping_category.name).select_option
 
         click_button 'Create'
 
         expect(page).to have_content('successfully created!')
         expect(page).to have_field(id: 'product_status', with: 'draft')
-        expect(Spree::Product.last.variants.length).to eq(1)
+        expect(Spree::Product.last.variants.length).to eq(6)
       end
 
       it 'does not display variants when prototype does not contain option types' do


### PR DESCRIPTION
Due to Rails bug with sending nested parameters via post parameters there was an issue with missing variants when adding a new product with selected prototype. This PR changes approach to sending the data, fixing the issue.