### PR TITLE
Fix lists plugin configuration for TinyMCE

### DIFF
--- a/app/assets/javascripts/spree/backend/global/tinymce.es6
+++ b/app/assets/javascripts/spree/backend/global/tinymce.es6
@@ -4,7 +4,7 @@ document.addEventListener("spree:load", function() {
   tinymce.init({
     selector: '.spree-rte',
     plugins: [
-      'image table paste code link table'
+      'image table paste code link table lists'
     ],
     menubar: false,
     toolbar: 'undo redo | styleselect | bold italic link forecolor backcolor | alignleft aligncenter alignright alignjustify | table | bullist numlist outdent indent | code '
@@ -14,7 +14,7 @@ document.addEventListener("spree:load", function() {
     selector: '.spree-rte-simple',
     menubar: false,
     plugins: [
-      'image table paste link table'
+      'image table paste link table lists'
     ],
     toolbar: 'undo redo | styleselect | bold italic link forecolor backcolor | alignleft aligncenter alignright alignjustify | table | bullist numlist outdent indent'
   });


### PR DESCRIPTION
According to TinyMCE docs, in order to have a lists feature in TinyMCE, one needs to add `lists` plugin to `lists` array. It's not configured this way in spree_backend therefore list buttons specified in `toolbar` are not being respected and end user is not being able to add/edit lists.

https://www.tiny.cloud/docs/plugins/opensource/lists/