### PR TITLE
Fix Promotions#index view when a promotion has expires_at set

### DIFF
--- a/app/views/spree/admin/promotions/index.html.erb
+++ b/app/views/spree/admin/promotions/index.html.erb
@@ -64,7 +64,7 @@
             <td><%= promotion.description %></td>
             <td><%= promotion.usage_limit.nil? ? "∞" : promotion.usage_limit %></td>
             <td><%= Spree.t(:current_promotion_usage, count: promotion.credits_count) %></td>
-            <td><%= promotion.expires_at.to_date if promotion.expires_at %></td>
+            <td><%= promotion.expires_at.strftime('%F %T %Z') if promotion.expires_at %></td>
             <td class="actions" data-hook="admin_promotions_index_row_actions">
               <span class="d-flex justify-content-end">
                <%= link_to_edit promotion, no_text: true if can?(:edit, promotion) %>

--- a/app/views/spree/admin/promotions/index.html.erb
+++ b/app/views/spree/admin/promotions/index.html.erb
@@ -64,7 +64,7 @@
             <td><%= promotion.description %></td>
             <td><%= promotion.usage_limit.nil? ? "∞" : promotion.usage_limit %></td>
             <td><%= Spree.t(:current_promotion_usage, count: promotion.credits_count) %></td>
-            <td><%= promotion.expires_at.to_date.to_s(:short_date) if promotion.expires_at %></td>
+            <td><%= promotion.expires_at.to_date if promotion.expires_at %></td>
             <td class="actions" data-hook="admin_promotions_index_row_actions">
               <span class="d-flex justify-content-end">
                <%= link_to_edit promotion, no_text: true if can?(:edit, promotion) %>


### PR DESCRIPTION
### **What?**
Fix Promotions#index view when a promotion has `expires_at` set.
https://upsidelab.atlassian.net/browse/SP-178

### **Why?**
Promotion#index view breaks due to an `ArgumentError`:
`(wrong number of arguments (given 1, expected 0) (ArgumentError))`

### **How?**
Deletion of unnecessary conversion to String (along with faulty argument passing).