### PR TITLE
[SP-103] Register custom fragments in the admin panel forms

### DIFF
--- a/app/helpers/spree/admin/extension_partials_helper.rb
+++ b/app/helpers/spree/admin/extension_partials_helper.rb
@@ -1,0 +1,27 @@
+module Spree
+  module Admin
+    module ExtensionPartialsHelper
+      def render_matching(pattern:nil, locals: {})
+        old_path = Dir.pwd
+        rendered = ''
+        return rendered if pattern.nil?
+
+        view_paths.paths.each do |view_path|
+          Dir.chdir(view_path)
+          result = Dir['spree/admin/extension/**/*'].select do |path|
+            !File.directory?(path) && File.basename(path, '.html.erb') =~ /^_.+/
+          end
+
+          result.map! { |path| path.gsub(File.basename(path), File.basename(path, '.html.erb')[1..-1]) }
+          result.each do |path|
+            if path.match(/.+\/#{pattern}\/.+/)
+              rendered += render partial: path, locals: locals
+            end
+          end
+        end
+        Dir.chdir(old_path)
+        rendered
+      end
+    end
+  end
+end

--- a/app/views/spree/admin/products/edit.html.erb
+++ b/app/views/spree/admin/products/edit.html.erb
@@ -2,23 +2,24 @@
   <% product_actions.items.each do |action| %>
     <% next unless action.available?(current_ability) %>
     <%= button_link_to(
-      Spree.t(action.label_translation_key),
-      action.url(@product),
-      class: action.classes,
-      icon: action.icon_key,
-      id: action.id,
-      target: action.target,
-      data: action.data_attributes
-    ) %>
+          Spree.t(action.label_translation_key),
+          action.url(@product),
+          class: action.classes,
+          icon: action.icon_key,
+          id: action.id,
+          target: action.target,
+          data: action.data_attributes
+        ) %>
   <% end if product_actions&.items %>
 <% end %>
 
-<%= render partial: 'spree/admin/shared/product_tabs', locals: {current: :details} %>
+<%= render partial: 'spree/admin/shared/product_tabs', locals: { current: :details } %>
 <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @product } %>
 
 <%= form_for [:admin, @product], method: :put, html: { multipart: true } do |f| %>
   <fieldset>
     <%= render partial: 'form', locals: { f: f } %>
+    <%= render_matching pattern: 'products/edit', locals: { f: f }  %>
     <%= render partial: 'spree/admin/shared/edit_resource_links' %>
   </fieldset>
 <% end %>


### PR DESCRIPTION
## Purpose
The idea is to allow extensions register custom fields or fragments in Admin Panel forms without using Deface. This PR proposes an implementation for such feature. <ins> It is a concept draft, the actual implementation might change in the future.</ins>
## Registering a partial 
For a partial to be rendered via this method:
```ruby
<%= render_matching pattern: 'products/edit', locals: { f: f }  %>
```
The partial must be located in `app/views/spree/admin/extension/.../products/edit` extension directory. The `...` means that there can be any directories along the way, preferably there would be a directory with a unique name (e.g. extension name) so that there are no conflicts between partials.