### PR TITLE
Check if flatpickr instance is available before destroying it to ensu…

### DIFF
--- a/app/assets/javascripts/spree/backend/global/flatpickr.es6
+++ b/app/assets/javascripts/spree/backend/global/flatpickr.es6
@@ -23,7 +23,9 @@ document.addEventListener("spree:load", function() {
 
 document.addEventListener("turbo:before-cache", function() {
   document.querySelectorAll('.datePickerFrom, .datePickerTo, .datepicker').forEach(function(element) {
-    element._flatpickr.destroy()
+    if (element._flatpickr) {
+      element._flatpickr.destroy()
+    }
   })
 })
 


### PR DESCRIPTION
…re we don't run destroy on uninitialized elements

This fixes the error that occurs on navigation from a page that has a flatpickr like an admin orders page.

<img width="659" alt="image" src="https://github.com/user-attachments/assets/86723a91-904d-468e-aa1d-1214f05efe8c">
