### PR TITLE
Remove `yaml_column_permitted_classes`

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,6 +1,1 @@
 Rails.application.config.assets.precompile << 'spree_backend_manifest.js'
-
-Rails.application.config.assets.configure do |env|
-  env.export_concurrent = false
-  Rails.application.config.active_record.yaml_column_permitted_classes = [Symbol, BigDecimal, ActiveSupport::HashWithIndifferentAccess]
-end


### PR DESCRIPTION
This is already set in spree core - https://github.com/spree/spree/commit/9b0d993697faa435023f9b2c7ffa478262cec8d5