### PR TITLE
Y-axis scroll for store switcher

### DIFF
--- a/app/views/spree/admin/shared/_store_switcher.html.erb
+++ b/app/views/spree/admin/shared/_store_switcher.html.erb
@@ -8,7 +8,7 @@
      <span class="d-none d-sm-inline"><%= current_store.name %></span> (<%= current_store.code %>) <%= svg_icon name: "chevron-down.svg", width: '12', height: '12', classes: 'ml-1 mb-0' %>
     </a>
 
-    <div class="dropdown-menu dropdown-menu-left overflow-hidden ml-2" aria-labelledby="storeSelectorDropdown">
+    <div class="dropdown-menu dropdown-menu-left ml-2" style="overflow-y: auto !important;" aria-labelledby="storeSelectorDropdown">
       <% @stores.each do |store| %>
         <%= store_switcher_link(store) %>
       <% end %>


### PR DESCRIPTION
With a large number of stores created, some of them might be trimmed together with the `Add new store button`. Also, the `overflow-hidden` class is redundant here. Unfortunately, the bootstrap `overflow` rule is rewritten by a rule from the `show` class, so I had to do it using the `style` tag and the `!important` rule.