### PR TITLE
Add translation for default currency label in form

### DIFF
--- a/app/views/spree/admin/stores/form/_internationalization.html.erb
+++ b/app/views/spree/admin/stores/form/_internationalization.html.erb
@@ -37,7 +37,7 @@
     <% end %>
     <hr />
     <%= f.field_container :default_locale do %>
-      <%= f.label :default_locale %>
+      <%= f.label :default_locale, Spree.t(:default_locale) %>
       <%= f.select :default_locale, options_from_collection_for_select(all_locales_options, :last, :first, @store.default_locale || I18n.locale), {}, { class: 'select2' } %>
       <%= f.error_message_on :default_locale %>
       <small class="form-text text-muted">

--- a/app/views/spree/admin/stores/form/_internationalization.html.erb
+++ b/app/views/spree/admin/stores/form/_internationalization.html.erb
@@ -6,7 +6,7 @@
   </div>
   <div class="card-body">
     <%= f.field_container :default_currency do %>
-      <%= f.label :default_currency %>
+      <%= f.label :default_currency, Spree.t(:default_currency) %>
       <%= f.select :default_currency, currency_options(@store.default_currency), {}, { class: 'select2' } %>
       <%= f.error_message_on :default_currency %>
     <% end %>


### PR DESCRIPTION
## Summary:

This PR updates the form label for the default currency field to utilize the Spree translation system, ensuring that the label can be easily translated into multiple languages.

## Reason:

This change enhances the internationalization (i18n) support by enabling dynamic translations for the default currency label, making the platform more accessible to users in different languages.

## Impact:

No functional changes for users using the default language, but the label will now reflect the appropriate translation when other languages are in use.